### PR TITLE
feat: add ReACT follow-up agent with tool-based exploration and edits

### DIFF
--- a/backend/app/ai/agent.py
+++ b/backend/app/ai/agent.py
@@ -20,7 +20,6 @@ from app.ai.provider import complete_chat, stream_chat
 from app.sandbox.nsjail import exec_in_sandbox
 from app.ai.task_tree import Task, WorkPlan
 from app.ai.prompts import (
-    CLASSIFY_PROMPT,
     ARCHITECTURE_PROMPT,
     UX_DESIGN_PROMPT,
     USER_PLAN_PROMPT,
@@ -112,7 +111,16 @@ class AgentOrchestrator:
         is_new = await self._classify(content)
 
         if not is_new:
-            await self._simple_flow(content)
+            from app.ai.followup_agent import FollowUpAgent
+
+            agent = FollowUpAgent(
+                session_id=self.session_id,
+                project_id=self.project_id,
+                ws_send=self.ws_send,
+                model=self.model,
+                trace_id=self._trace_id,
+            )
+            await agent.run(content)
             return
 
         # 2. Fetch package data if package_id is provided
@@ -262,13 +270,13 @@ class AgentOrchestrator:
 
     @observe(name="classify-request", as_type="span")
     async def _classify(self, content: str) -> bool:
-        """Return True if this is a new project request, False for follow-up."""
+        """Return True if this is a new project request, False for follow-up.
+
+        Deterministic: if the project already has assistant messages, it's
+        always a follow-up.  Only the very first message is treated as new.
+        """
         history = await get_messages(self.project_id)
-        # Only count real assistant messages, not card metadata
-        assistant_msgs = [
-            m for m in history
-            if m.role == "assistant" and not m.content.startswith(CARD_PREFIX)
-        ]
+        assistant_msgs = [m for m in history if m.role == "assistant"]
         if len(assistant_msgs) == 0:
             logger.info("[agent] First message — classifying as new_project")
             langfuse_context.update_current_observation(
@@ -276,41 +284,11 @@ class AgentOrchestrator:
             )
             return True
 
-        # Include project summary for classifier context
-        classify_content = content
-        project = await get_project_by_session(self.session_id)
-        if project and project.summary:
-            try:
-                summary_data = json.loads(project.summary)
-                classify_content = (
-                    f"[Existing project: {summary_data.get('summary', '')}]\n\n"
-                    f"User message: {content}"
-                )
-            except (json.JSONDecodeError, AttributeError):
-                pass
-
-        messages = [{"role": "user", "content": classify_content}]
-        try:
-            raw = await complete_chat(
-                messages,
-                CLASSIFY_PROMPT,
-                model=self.model,
-                metadata=self._llm_metadata("classify")
-            )
-            data = json.loads(raw.strip())
-            classification = data.get("classification", "follow_up")
-            logger.info("[agent] Classification: %s", classification)
-            is_new = classification == "new_project"
-            langfuse_context.update_current_observation(
-                metadata={"classification": classification, "is_new_project": is_new}
-            )
-            return is_new
-        except Exception:
-            logger.exception("[agent] Classification failed, defaulting to follow_up")
-            langfuse_context.update_current_observation(
-                metadata={"classification": "follow_up", "reason": "error_fallback"}
-            )
-            return False
+        logger.info("[agent] Existing project — classifying as follow_up")
+        langfuse_context.update_current_observation(
+            metadata={"classification": "follow_up", "reason": "has_assistant_messages"}
+        )
+        return False
 
     async def _fetch_and_analyze_package(self, package_id: str) -> dict | None:
         """Fetch package data and analyze it with AI.

--- a/backend/app/ai/followup_agent.py
+++ b/backend/app/ai/followup_agent.py
@@ -1,0 +1,406 @@
+"""ReACT-loop follow-up agent for codebase exploration and targeted edits."""
+
+from __future__ import annotations
+
+import asyncio
+import difflib
+import json
+import logging
+import os
+import uuid
+from collections.abc import Callable, Awaitable
+from dataclasses import dataclass
+from pathlib import Path
+
+from langfuse.decorators import observe, langfuse_context
+
+from app.ai.provider import complete_chat_with_tools
+from app.ai.prompts.followup import FOLLOWUP_SYSTEM_PROMPT, FOLLOWUP_TOOLS
+from app.models.chat import get_messages, save_message
+from app.models.project import get_project_by_session
+from app.sandbox.filesystem import read_file, write_file, list_files
+from app.sandbox.manager import sandbox_manager
+
+logger = logging.getLogger(__name__)
+
+CARD_PREFIX = "<!--agent-card:"
+CARD_SUFFIX = "-->"
+
+MAX_ITERATIONS = 15
+
+
+@dataclass
+class FileDiff:
+    path: str
+    diff: str  # unified diff string
+
+
+def _encode_card(card_data: dict) -> str:
+    return f"{CARD_PREFIX}{json.dumps(card_data, separators=(',', ':'))}{CARD_SUFFIX}"
+
+
+def _make_diff(path: str, old: str, new: str) -> str:
+    old_lines = old.splitlines(keepends=True)
+    new_lines = new.splitlines(keepends=True)
+    return "".join(difflib.unified_diff(
+        old_lines, new_lines,
+        fromfile=f"a/{path}", tofile=f"b/{path}",
+        lineterm="",
+    ))
+
+
+class FollowUpAgent:
+    """ReACT agent that explores the codebase before making targeted edits."""
+
+    def __init__(
+        self,
+        session_id: str,
+        project_id: str,
+        ws_send: Callable[[dict], Awaitable[None]],
+        model: str | None = None,
+        trace_id: str | None = None,
+    ) -> None:
+        self.session_id = session_id
+        self.project_id = project_id
+        self.ws_send = ws_send
+        self.model = model
+        self.trace_id = trace_id
+        self._steps: list[dict] = []
+        self._diffs: list[FileDiff] = []
+        self._files_changed: list[str] = []
+        self._iteration = 0
+
+    def _llm_metadata(self, generation_name: str) -> dict:
+        trace_id = self.trace_id or langfuse_context.get_current_trace_id()
+        observation_id = langfuse_context.get_current_observation_id()
+        return {
+            "existing_trace_id": trace_id,
+            "parent_observation_id": observation_id,
+            "generation_name": generation_name,
+        }
+
+    # ------------------------------------------------------------------
+    # Main entry point
+    # ------------------------------------------------------------------
+
+    @observe(name="followup-run")
+    async def run(self, content: str) -> None:
+        """Process a follow-up message using the ReACT loop."""
+        langfuse_context.update_current_observation(
+            tags=["follow-up-agent"],
+        )
+
+        # 1. Build context
+        await self.ws_send({"type": "phase", "phase": "exploring"})
+        context = await self._build_context()
+
+        # 2. Load chat history
+        history = await get_messages(self.project_id)
+        messages = [
+            {"role": m.role, "content": m.content}
+            for m in history
+            if not m.content.startswith(CARD_PREFIX)
+        ]
+
+        # 3. ReACT loop (tools handle both reads AND writes)
+        system_prompt = FOLLOWUP_SYSTEM_PROMPT.format(
+            project_summary=context["summary"],
+            file_tree=context["file_tree"],
+        )
+        answer = await self._react_loop(messages, system_prompt)
+
+        # 4. Stream the final text answer to the client
+        if answer:
+            await self.ws_send({"type": "text", "content": answer})
+
+        # 5. Save message and send completion
+        card = _encode_card({
+            "type": "followup_progress",
+            "steps": self._steps,
+            "answer": answer or None,
+            "filesChanged": self._files_changed,
+            "diffs": [{"path": d.path, "diff": d.diff} for d in self._diffs],
+        })
+        assistant_content = (answer + "\n" + card) if answer else card
+        await save_message(self.project_id, "assistant", assistant_content)
+
+        # Send diffs to frontend for live card rendering
+        if self._diffs:
+            await self.ws_send({
+                "type": "followup_diffs",
+                "diffs": [{"path": d.path, "diff": d.diff} for d in self._diffs],
+            })
+
+        await self.ws_send({"type": "phase", "phase": "complete"})
+        await self.ws_send({"type": "action_complete"})
+
+    # ------------------------------------------------------------------
+    # Context building
+    # ------------------------------------------------------------------
+
+    @observe(name="followup-build-context")
+    async def _build_context(self) -> dict:
+        project = await get_project_by_session(self.session_id)
+        summary = ""
+        if project and project.summary:
+            try:
+                summary_data = json.loads(project.summary)
+                summary = (
+                    f"{summary_data.get('summary', '')}\n"
+                    f"Tech stack: {', '.join(summary_data.get('tech_stack', []))}\n"
+                    f"Features: {', '.join(summary_data.get('features', []))}\n"
+                )
+            except (json.JSONDecodeError, AttributeError):
+                summary = "(no project summary available)"
+
+        try:
+            file_entries = await list_files(self.session_id)
+            file_tree = self._format_file_tree(file_entries)
+        except Exception:
+            file_tree = "(unable to list files)"
+
+        return {"summary": summary, "file_tree": file_tree}
+
+    def _format_file_tree(self, entries, indent: int = 0) -> str:
+        lines = []
+        for entry in entries:
+            prefix = "  " * indent
+            if entry.is_directory:
+                lines.append(f"{prefix}{entry.name}/")
+                if entry.children:
+                    lines.append(self._format_file_tree(entry.children, indent + 1))
+            else:
+                lines.append(f"{prefix}{entry.name}")
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # ReACT loop
+    # ------------------------------------------------------------------
+
+    @observe(name="followup-react-loop")
+    async def _react_loop(self, messages: list[dict], system_prompt: str) -> str:
+        """Core ReACT loop: call LLM, execute tools, repeat until done."""
+        working_messages = list(messages)
+        last_content = ""
+
+        for self._iteration in range(MAX_ITERATIONS):
+            response = await complete_chat_with_tools(
+                messages=working_messages,
+                system_prompt=system_prompt,
+                tools=FOLLOWUP_TOOLS,
+                model=self.model,
+                metadata=self._llm_metadata(f"followup-react-{self._iteration}"),
+            )
+
+            choice = response.choices[0]
+            message = choice.message
+            last_content = message.content or ""
+
+            if not message.tool_calls:
+                return last_content
+
+            working_messages.append(message.model_dump())
+
+            for tool_call in message.tool_calls:
+                tool_name = tool_call.function.name
+                try:
+                    args = json.loads(tool_call.function.arguments)
+                except json.JSONDecodeError:
+                    args = {}
+
+                # Send running step
+                step_data = {
+                    "tool": tool_name,
+                    "args": {k: v for k, v in args.items() if k != "content"},
+                    "status": "running",
+                    "iteration": self._iteration,
+                }
+                await self.ws_send({"type": "followup_step", **step_data})
+
+                # Execute tool
+                result = await self._execute_tool(tool_name, args)
+
+                # Send completed step
+                preview = result[:200] + "..." if len(result) > 200 else result
+                step_data["status"] = "completed"
+                step_data["result_preview"] = preview
+                await self.ws_send({"type": "followup_step", **step_data})
+
+                # Track step for card persistence
+                self._steps.append({
+                    "id": str(uuid.uuid4()),
+                    "tool": tool_name,
+                    "args": {k: v for k, v in args.items() if k != "content"},
+                    "status": "completed",
+                    "resultPreview": preview,
+                    "iteration": self._iteration,
+                })
+
+                working_messages.append({
+                    "role": "tool",
+                    "tool_call_id": tool_call.id,
+                    "content": result,
+                })
+
+        logger.warning("[followup-agent] Hit max iterations (%d)", MAX_ITERATIONS)
+        return last_content
+
+    # ------------------------------------------------------------------
+    # Tool implementations
+    # ------------------------------------------------------------------
+
+    @observe(name="followup-execute-tool")
+    async def _execute_tool(self, tool_name: str, args: dict) -> str:
+        try:
+            if tool_name == "grep":
+                return await self._tool_grep(
+                    args["pattern"],
+                    args.get("path", "/"),
+                    args.get("file_pattern"),
+                )
+            elif tool_name == "glob":
+                return await self._tool_glob(args["pattern"])
+            elif tool_name == "read_file":
+                return await self._tool_read_file(args["path"])
+            elif tool_name == "write_file":
+                return await self._tool_write_file(args["path"], args["content"])
+            elif tool_name == "edit_file":
+                return await self._tool_edit_file(
+                    args["path"], args["search"], args["replace"],
+                )
+            else:
+                return f"Unknown tool: {tool_name}"
+        except Exception as e:
+            return f"Error: {e}"
+
+    async def _tool_grep(self, pattern: str, path: str = "/", file_pattern: str | None = None) -> str:
+        """Run ripgrep in the sandbox workspace."""
+        sandbox = sandbox_manager.get_sandbox(self.session_id)
+        if sandbox is None:
+            return "Error: No sandbox found"
+
+        workspace = os.path.realpath(sandbox.workspace_dir)
+        search_path = os.path.realpath(os.path.join(workspace, path.lstrip("/")))
+
+        if not search_path.startswith(workspace):
+            return "Error: Path traversal detected"
+
+        cmd = [
+            "rg", "--no-heading", "--line-number", "--max-count", "50",
+            "--glob", "!node_modules",
+            "--glob", "!.git",
+            "--glob", "!dist",
+            "--glob", "!.next",
+        ]
+        if file_pattern:
+            cmd.extend(["--glob", file_pattern])
+        cmd.extend([pattern, search_path])
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+            output = stdout.decode("utf-8", errors="replace")
+
+            lines = []
+            for line in output.splitlines()[:50]:
+                if line.startswith(workspace):
+                    line = line[len(workspace):]
+                lines.append(line)
+
+            if not lines:
+                return "No matches found."
+            return "\n".join(lines)
+        except asyncio.TimeoutError:
+            return "Error: grep timed out"
+        except FileNotFoundError:
+            return "Error: ripgrep (rg) not available"
+
+    async def _tool_glob(self, pattern: str) -> str:
+        """Find files matching a glob pattern in the sandbox."""
+        sandbox = sandbox_manager.get_sandbox(self.session_id)
+        if sandbox is None:
+            return "Error: No sandbox found"
+
+        workspace = Path(os.path.realpath(sandbox.workspace_dir))
+        SKIP = {"node_modules", ".git", "dist", ".next", ".cache", "__pycache__"}
+
+        results = []
+        for p in workspace.glob(pattern):
+            if any(part in SKIP for part in p.parts):
+                continue
+            rel = "/" + str(p.relative_to(workspace))
+            results.append(rel)
+            if len(results) >= 100:
+                break
+
+        if not results:
+            return "No files found matching pattern."
+        return "\n".join(sorted(results))
+
+    async def _tool_read_file(self, path: str) -> str:
+        """Read a file from the sandbox with line numbers."""
+        try:
+            content = await read_file(self.session_id, path)
+        except (FileNotFoundError, PermissionError) as e:
+            return f"Error: {e}"
+
+        lines = content.splitlines()
+        if len(lines) > 500:
+            lines = lines[:500]
+            numbered = [f"{i + 1:4d} | {line}" for i, line in enumerate(lines)]
+            numbered.append(f"\n... (truncated at 500 lines, file has {len(content.splitlines())} total)")
+            return "\n".join(numbered)
+
+        return "\n".join(f"{i + 1:4d} | {line}" for i, line in enumerate(lines))
+
+    async def _tool_write_file(self, path: str, content: str) -> str:
+        """Write full file content, creating it if needed. Returns diff."""
+        try:
+            old_content = await read_file(self.session_id, path)
+        except FileNotFoundError:
+            old_content = ""
+
+        await write_file(self.session_id, path, content)
+        await self.ws_send({"type": "file", "path": path, "content": content})
+
+        diff_str = _make_diff(path, old_content, content)
+        if diff_str:
+            self._diffs.append(FileDiff(path=path, diff=diff_str))
+        if path not in self._files_changed:
+            self._files_changed.append(path)
+
+        return f"OK — wrote {path} ({len(content.splitlines())} lines)"
+
+    async def _tool_edit_file(self, path: str, search: str, replace: str) -> str:
+        """Search-and-replace edit. Returns diff on success, error with file content on failure."""
+        try:
+            current = await read_file(self.session_id, path)
+        except FileNotFoundError:
+            return f"Error: File not found: {path}"
+
+        if search not in current:
+            lines = current.splitlines()
+            snippet = "\n".join(lines[:40])
+            if len(lines) > 40:
+                snippet += f"\n... ({len(lines)} lines total)"
+            return (
+                f"Error: search string not found in {path}. "
+                f"The search must match the file exactly (including whitespace).\n\n"
+                f"Current file content:\n```\n{snippet}\n```"
+            )
+
+        new_content = current.replace(search, replace, 1)
+        await write_file(self.session_id, path, new_content)
+        await self.ws_send({"type": "file", "path": path, "content": new_content})
+
+        diff_str = _make_diff(path, current, new_content)
+        if diff_str:
+            self._diffs.append(FileDiff(path=path, diff=diff_str))
+        if path not in self._files_changed:
+            self._files_changed.append(path)
+
+        return f"OK — edited {path}"

--- a/backend/app/ai/parser.py
+++ b/backend/app/ai/parser.py
@@ -41,6 +41,9 @@ class ActionParser:
         Fired when a complete ``<boltAction type="file">`` is parsed.
     on_shell_action(command: str)
         Fired when a complete ``<boltAction type="shell">`` is parsed.
+    on_edit_action(path: str, search_str: str, replace_str: str)
+        Fired when a complete ``<boltAction type="edit">`` with
+        ``<search>``/``<replace>`` children is parsed.
     """
 
     def __init__(
@@ -48,10 +51,12 @@ class ActionParser:
         on_text: Callable[[str], None] | None = None,
         on_file_action: Callable[[str, str], None] | None = None,
         on_shell_action: Callable[[str], None] | None = None,
+        on_edit_action: Callable[[str, str, str], None] | None = None,
     ) -> None:
         self.on_text = on_text or (lambda _t: None)
         self.on_file_action = on_file_action or (lambda _p, _c: None)
         self.on_shell_action = on_shell_action or (lambda _c: None)
+        self.on_edit_action = on_edit_action or (lambda _p, _s, _r: None)
 
         self._buffer: str = ""
         self._state: _State = _State.TEXT
@@ -146,11 +151,23 @@ class ActionParser:
                     self.on_file_action(self._action_file_path, body)
                 elif self._action_type == "shell":
                     self.on_shell_action(body)
+                elif self._action_type == "edit":
+                    self._parse_edit_action(self._action_file_path, body)
 
                 self._action_type = ""
                 self._action_file_path = ""
                 self._action_body = ""
                 self._state = _State.IN_ARTIFACT
+
+    _SEARCH_RE = re.compile(r"<search>\n?(.*?)\n?</search>", re.DOTALL)
+    _REPLACE_RE = re.compile(r"<replace>\n?(.*?)\n?</replace>", re.DOTALL)
+
+    def _parse_edit_action(self, path: str, body: str) -> None:
+        """Extract ``<search>``/``<replace>`` pairs from an edit action body."""
+        searches = self._SEARCH_RE.findall(body)
+        replaces = self._REPLACE_RE.findall(body)
+        for search_str, replace_str in zip(searches, replaces):
+            self.on_edit_action(path, search_str, replace_str)
 
     def flush(self) -> None:
         """Flush any remaining buffered text (call at end of stream)."""

--- a/backend/app/ai/prompts/__init__.py
+++ b/backend/app/ai/prompts/__init__.py
@@ -7,6 +7,7 @@ from app.ai.prompts.merge import MERGE_PROMPT
 from app.ai.prompts.user_plan import USER_PLAN_PROMPT
 from app.ai.prompts.codegen import get_codegen_prompt
 from app.ai.prompts.summary import SUMMARY_PROMPT
+from app.ai.prompts.followup import FOLLOWUP_SYSTEM_PROMPT, FOLLOWUP_TOOLS
 
 __all__ = [
     "CLASSIFY_PROMPT",
@@ -16,4 +17,6 @@ __all__ = [
     "USER_PLAN_PROMPT",
     "get_codegen_prompt",
     "SUMMARY_PROMPT",
+    "FOLLOWUP_SYSTEM_PROMPT",
+    "FOLLOWUP_TOOLS",
 ]

--- a/backend/app/ai/prompts/followup.py
+++ b/backend/app/ai/prompts/followup.py
@@ -1,0 +1,142 @@
+"""Prompts and tool definitions for the follow-up ReACT agent."""
+
+from __future__ import annotations
+
+FOLLOWUP_SYSTEM_PROMPT = """\
+You are an expert full-stack web developer assistant. You help users understand and modify their existing codebase.
+
+## Current Project
+{project_summary}
+
+## File Tree
+{file_tree}
+
+## How to Work
+
+Follow the EXPLORE → REASON → ACT pattern:
+
+1. **EXPLORE**: Use tools (grep, glob, read_file) to understand the codebase before making changes. \
+Do NOT guess what the code looks like — always read the relevant files first.
+
+2. **REASON**: Think step by step about what needs to change and why. Consider side effects and imports.
+
+3. **ACT**: Either:
+   - Answer the user's question in plain text (for questions about the code), OR
+   - Use `write_file` for new files or full rewrites, and `edit_file` for targeted changes.
+
+## Rules for editing
+- Always `read_file` before `edit_file` — the search string must match the file EXACTLY.
+- Prefer `edit_file` for small, targeted changes. Use `write_file` for new files or when most of the file changes.
+- Keep changes minimal and focused on what the user asked for.
+- If the user asks a question, answer it in text. Only make edits if the user wants changes.
+- Do NOT include shell commands.
+"""
+
+FOLLOWUP_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "grep",
+            "description": "Search for a pattern in the codebase using regex. Returns matching lines with file paths and line numbers. Use this to find where specific code, imports, or patterns are used.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "pattern": {
+                        "type": "string",
+                        "description": "Regex pattern to search for (e.g. 'useState', 'className=\"btn')",
+                    },
+                    "path": {
+                        "type": "string",
+                        "description": "Directory to search in, relative to project root. Defaults to '/' (entire project).",
+                        "default": "/",
+                    },
+                    "file_pattern": {
+                        "type": "string",
+                        "description": "Glob to filter files (e.g. '*.tsx', '*.css'). Optional.",
+                    },
+                },
+                "required": ["pattern"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "glob",
+            "description": "Find files matching a glob pattern. Returns file paths. Use this to discover project structure or find files by name.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "pattern": {
+                        "type": "string",
+                        "description": "Glob pattern (e.g. 'src/**/*.tsx', '**/*.css', 'src/components/*')",
+                    },
+                },
+                "required": ["pattern"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read the full content of a file. Returns the file with line numbers. Always read a file before editing it.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "File path relative to project root (e.g. 'src/App.tsx')",
+                    },
+                },
+                "required": ["path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "write_file",
+            "description": "Write the full content of a file, creating it if it doesn't exist. Use for new files or when rewriting most of the file. For small changes, prefer edit_file instead.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "File path relative to project root (e.g. 'src/App.tsx')",
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "The complete file content to write.",
+                    },
+                },
+                "required": ["path", "content"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "edit_file",
+            "description": "Apply a targeted search-and-replace edit to an existing file. The search string must match the file content exactly (including whitespace). Always read_file first to get the exact content. If the search fails, you'll get an error with the current file content — use it to retry.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "File path relative to project root (e.g. 'src/App.tsx')",
+                    },
+                    "search": {
+                        "type": "string",
+                        "description": "The exact string to find in the file. Must match whitespace and indentation exactly.",
+                    },
+                    "replace": {
+                        "type": "string",
+                        "description": "The string to replace the search match with.",
+                    },
+                },
+                "required": ["path", "search", "replace"],
+            },
+        },
+    },
+]

--- a/backend/app/ai/provider.py
+++ b/backend/app/ai/provider.py
@@ -46,6 +46,37 @@ async def complete_chat(
     return content
 
 
+async def complete_chat_with_tools(
+    messages: list[dict],
+    system_prompt: str,
+    tools: list[dict],
+    model: str | None = None,
+    metadata: dict | None = None,
+    tool_choice: str = "auto",
+):
+    """Non-streaming completion with tool/function calling support.
+
+    Returns the full response object so the caller can inspect ``tool_calls``.
+    """
+    resolved_model = model or settings.AI_MODEL
+
+    full_messages: list[dict] = [
+        {"role": "system", "content": system_prompt},
+        *messages,
+    ]
+
+    response = await litellm.acompletion(
+        model=resolved_model,
+        messages=full_messages,
+        tools=tools,
+        tool_choice=tool_choice,
+        stream=False,
+        metadata=metadata or {},
+    )
+
+    return response
+
+
 async def stream_chat(
     messages: list[dict],
     system_prompt: str,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.4)
@@ -291,6 +294,10 @@ packages:
   dompurify@3.2.7:
     resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
@@ -417,13 +424,37 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   marked@14.0.0:
     resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
     engines: {node: '>= 18'}
     hasBin: true
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -448,6 +479,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -552,11 +604,17 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   rolldown@1.0.0-rc.9:
     resolution: {integrity: sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==}
@@ -871,6 +929,8 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
+  escape-string-regexp@5.0.0: {}
+
   estree-util-is-identifier-name@3.0.0: {}
 
   extend@3.0.2: {}
@@ -978,7 +1038,16 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  markdown-table@3.0.4: {}
+
   marked@14.0.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   mdast-util-from-markdown@2.0.3:
     dependencies:
@@ -994,6 +1063,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -1086,6 +1212,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -1258,6 +1442,17 @@ snapshots:
 
   react@19.2.4: {}
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -1274,6 +1469,12 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   rolldown@1.0.0-rc.9:
     dependencies:

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
-import { FileText, TerminalSquare, Sparkles, CheckCircle2, XCircle, ArrowRight, Check, X, Package, AlertTriangle, ChevronDown, ChevronRight, Loader2, Search, Wrench, Save, TestTube, RefreshCw } from 'lucide-react';
-import type { Message, PlanOverview, ExecutionTask, ProjectSummary, FixStep } from '../../types';
+import remarkGfm from 'remark-gfm';
+import { FileText, TerminalSquare, Sparkles, CheckCircle2, XCircle, ArrowRight, Check, X, Package, AlertTriangle, ChevronDown, ChevronRight, Loader2, Search, Wrench, Save, TestTube, RefreshCw, FolderSearch, Pencil } from 'lucide-react';
+import type { Message, PlanOverview, ExecutionTask, ProjectSummary, FixStep, FollowUpStep, FileDiff } from '../../types';
 
 interface ChatMessageProps {
   message: Message;
@@ -455,6 +456,292 @@ function FixProgressCard({ steps, content }: { steps: FixStep[]; content?: strin
   );
 }
 
+function getFollowUpToolIcon(tool: FollowUpStep['tool']) {
+  switch (tool) {
+    case 'grep':
+      return Search;
+    case 'glob':
+      return FolderSearch;
+    case 'read_file':
+      return FileText;
+    case 'write_file':
+      return Save;
+    case 'edit_file':
+      return Pencil;
+  }
+}
+
+function getFollowUpToolLabel(tool: FollowUpStep['tool'], args: Record<string, string>, isRunning?: boolean) {
+  switch (tool) {
+    case 'grep':
+      return isRunning
+        ? `Searching for '${args.pattern || ''}'${args.path && args.path !== '/' ? ` in ${args.path}` : ''}`
+        : `Searched for '${args.pattern || ''}'${args.path && args.path !== '/' ? ` in ${args.path}` : ''}`;
+    case 'glob':
+      return isRunning ? `Finding files: ${args.pattern || ''}` : `Found files: ${args.pattern || ''}`;
+    case 'read_file':
+      return isRunning ? `Reading ${args.path || ''}` : `Read ${args.path || ''}`;
+    case 'write_file':
+      return isRunning ? `Writing ${args.path || ''}` : `Wrote ${args.path || ''}`;
+    case 'edit_file':
+      return isRunning ? `Editing ${args.path || ''}` : `Edited ${args.path || ''}`;
+  }
+}
+
+function DiffBlock({ fileDiff }: { fileDiff: FileDiff }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const lines = fileDiff.diff.split('\n');
+  // Count additions and deletions (skip header lines starting with --- +++ @@)
+  let additions = 0;
+  let deletions = 0;
+  for (const line of lines) {
+    if (line.startsWith('+') && !line.startsWith('+++')) additions++;
+    else if (line.startsWith('-') && !line.startsWith('---')) deletions++;
+  }
+
+  return (
+    <div style={{
+      border: '1px solid var(--border)',
+      borderRadius: '6px',
+      overflow: 'hidden',
+    }}>
+      <div
+        onClick={() => setIsExpanded(!isExpanded)}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '8px',
+          padding: '6px 10px',
+          background: 'var(--bg)',
+          cursor: 'pointer',
+          fontSize: '12px',
+        }}
+      >
+        {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        <FileText size={12} style={{ color: 'var(--accent)', flexShrink: 0 }} />
+        <span style={{ fontFamily: 'var(--font-mono)', flex: 1 }}>{fileDiff.path}</span>
+        <span style={{ display: 'flex', gap: '6px', fontSize: '11px', flexShrink: 0 }}>
+          {additions > 0 && <span style={{ color: '#a6e3a1' }}>+{additions}</span>}
+          {deletions > 0 && <span style={{ color: '#f38ba8' }}>-{deletions}</span>}
+        </span>
+      </div>
+      {isExpanded && (
+        <div style={{
+          overflow: 'auto',
+          maxHeight: '300px',
+          fontSize: '11px',
+          fontFamily: 'var(--font-mono)',
+          lineHeight: '1.5',
+        }}>
+          {lines.map((line, i) => {
+            // Skip empty trailing line
+            if (i === lines.length - 1 && line === '') return null;
+            let bg = 'transparent';
+            let color = 'var(--text-dim)';
+            if (line.startsWith('+') && !line.startsWith('+++')) {
+              bg = 'rgba(166, 227, 161, 0.1)';
+              color = '#a6e3a1';
+            } else if (line.startsWith('-') && !line.startsWith('---')) {
+              bg = 'rgba(243, 139, 168, 0.1)';
+              color = '#f38ba8';
+            } else if (line.startsWith('@@')) {
+              color = 'var(--accent)';
+            }
+            return (
+              <div
+                key={i}
+                style={{
+                  padding: '0 10px',
+                  background: bg,
+                  color,
+                  whiteSpace: 'pre',
+                  minHeight: '18px',
+                }}
+              >
+                {line}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function FollowUpProgress({ steps, answer, filesChanged, diffs, isLive }: {
+  steps: FollowUpStep[];
+  answer?: string;
+  filesChanged?: string[];
+  diffs?: FileDiff[];
+  isLive?: boolean;
+}) {
+  const completed = steps.filter((s) => s.status === 'completed').length;
+  const inProgress = isLive || steps.some((s) => s.status === 'running');
+  const hasDiffs = diffs && diffs.length > 0;
+
+  return (
+    <div style={{
+      background: 'var(--surface)',
+      border: '1px solid var(--border)',
+      borderRadius: '12px',
+      padding: '14px 16px',
+      fontSize: '13px',
+    }}>
+      {/* Header */}
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '6px',
+        marginBottom: '12px',
+        fontSize: '13px',
+        fontWeight: 500,
+        color: inProgress ? 'var(--accent)' : 'var(--success)',
+      }}>
+        {inProgress ? (
+          <>
+            <Loader2 size={14} style={{ animation: 'spin 1s linear infinite' }} />
+            Exploring codebase...
+          </>
+        ) : (
+          <>
+            <CheckCircle2 size={14} />
+            Done ({completed} {completed === 1 ? 'step' : 'steps'})
+          </>
+        )}
+      </div>
+
+      {/* Steps with previews */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+        {steps.map((step) => {
+          const ToolIcon = getFollowUpToolIcon(step.tool);
+          return (
+            <div
+              key={step.id}
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: '8px',
+                padding: '6px 8px',
+                borderRadius: '6px',
+                background: step.status === 'running' ? 'rgba(137, 180, 250, 0.08)' : 'transparent',
+                fontSize: '13px',
+                transition: 'background 0.2s',
+              }}
+            >
+              {step.status === 'running' ? (
+                <Loader2 size={14} style={{ color: 'var(--accent)', flexShrink: 0, marginTop: '1px', animation: 'spin 1s linear infinite' }} />
+              ) : (
+                <ToolIcon size={14} style={{ color: 'var(--success)', flexShrink: 0, marginTop: '1px' }} />
+              )}
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <span style={{ color: 'var(--text)' }}>
+                  {getFollowUpToolLabel(step.tool, step.args, step.status === 'running')}
+                </span>
+                {step.status === 'completed' && step.resultPreview && step.tool !== 'write_file' && step.tool !== 'edit_file' && (
+                  <div style={{
+                    marginTop: '4px',
+                    padding: '4px 6px',
+                    background: 'var(--bg)',
+                    borderRadius: '4px',
+                    fontSize: '11px',
+                    fontFamily: 'var(--font-mono)',
+                    color: 'var(--text-dim)',
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-all',
+                    maxHeight: '60px',
+                    overflow: 'hidden',
+                  }}>
+                    {step.resultPreview}
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Files changed with diffs */}
+      {hasDiffs && (
+        <div style={{ marginTop: '10px', borderTop: '1px solid var(--border)', paddingTop: '10px' }}>
+          <div style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+            marginBottom: '8px',
+            fontSize: '12px',
+            fontWeight: 500,
+            color: 'var(--text-dim)',
+          }}>
+            Files changed
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+            {diffs.map((d) => (
+              <DiffBlock key={d.path} fileDiff={d} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Fallback: file list without diffs */}
+      {!hasDiffs && filesChanged && filesChanged.length > 0 && (
+        <div style={{ marginTop: '10px', borderTop: '1px solid var(--border)', paddingTop: '10px' }}>
+          <div style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+            marginBottom: '6px',
+            fontSize: '12px',
+            fontWeight: 500,
+            color: 'var(--text-dim)',
+          }}>
+            Files changed
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '3px' }}>
+            {filesChanged.map((filePath) => (
+              <div
+                key={filePath}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '6px',
+                  padding: '4px 8px',
+                  borderRadius: '4px',
+                  fontSize: '12px',
+                }}
+              >
+                <FileText size={12} style={{ color: 'var(--accent)', flexShrink: 0 }} />
+                <span style={{ color: 'var(--text)', fontFamily: 'var(--font-mono)' }}>{filePath}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Answer text */}
+      {answer && (
+        <div className="markdown-content" style={{
+          marginTop: '10px',
+          borderTop: '1px solid var(--border)',
+          paddingTop: '10px',
+          fontSize: '13px',
+          lineHeight: '1.6',
+          color: 'var(--text)',
+          wordBreak: 'break-word',
+        }}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{answer}</ReactMarkdown>
+        </div>
+      )}
+
+      <style>{`
+        @keyframes spin {
+          from { transform: rotate(0deg); }
+          to { transform: rotate(360deg); }
+        }
+      `}</style>
+    </div>
+  );
+}
+
 export function ChatMessage({ message, isStreaming }: ChatMessageProps) {
   const isUser = message.role === 'user';
 
@@ -499,6 +786,9 @@ export function ChatMessage({ message, isStreaming }: ChatMessageProps) {
           {message.agentCard.type === 'fix_progress' && (
             <FixProgressCard steps={message.agentCard.steps} content={message.content} />
           )}
+          {message.agentCard.type === 'followup_progress' && (
+            <FollowUpProgress steps={message.agentCard.steps} answer={message.agentCard.answer} filesChanged={message.agentCard.filesChanged} diffs={message.agentCard.diffs} />
+          )}
         </div>
       </div>
     );
@@ -541,6 +831,7 @@ export function ChatMessage({ message, isStreaming }: ChatMessageProps) {
         ) : (
           <div className="markdown-content" style={{ wordBreak: 'break-word' }}>
             <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
               components={{
                 code({ children, className, ...props }) {
                   const isInline = !className;
@@ -637,6 +928,10 @@ export function ChatMessage({ message, isStreaming }: ChatMessageProps) {
         }
         .markdown-content p { margin: 4px 0; }
         .markdown-content ul, .markdown-content ol { padding-left: 20px; margin: 4px 0; }
+        .markdown-content table { border-collapse: collapse; width: 100%; margin: 8px 0; font-size: 12px; }
+        .markdown-content th, .markdown-content td { border: 1px solid var(--border); padding: 6px 10px; text-align: left; }
+        .markdown-content th { background: var(--bg); font-weight: 600; }
+        .markdown-content tr:nth-child(even) { background: rgba(255,255,255,0.02); }
       `}</style>
     </div>
   );

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useMemo, useState } from 'react';
 import { Loader2, CheckCircle2, Search, Wrench, Save, TestTube, RefreshCw, XCircle } from 'lucide-react';
 import { useChatStore } from '../../stores/chat';
-import { ChatMessage } from './ChatMessage';
+import { ChatMessage, FollowUpProgress } from './ChatMessage';
 import { PromptInput } from './PromptInput';
 import { ChevronDown, Check } from 'lucide-react';
 import { ThemeToggle } from '../layout/ThemeToggle';
@@ -169,6 +169,7 @@ const PHASE_LABELS: Record<AgentPhase, string> = {
   awaiting_approval: 'Review the plan below',
   executing: 'Building...',
   fixing: 'Fixing error...',
+  exploring: 'Exploring codebase...',
   complete: 'Done!',
 };
 
@@ -354,20 +355,21 @@ function PhaseIndicator({ phase }: { phase: AgentPhase }) {
 export function ChatPanel() {
   const {
     messages, isStreaming, currentAssistantMessage, actions, error, clearError,
-    agentPhase, planOverview, executionTasks, designProgress, fixSteps,
+    agentPhase, planOverview, executionTasks, designProgress, fixSteps, followUpSteps, followUpDiffs,
   } = useChatStore();
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages, currentAssistantMessage, agentPhase, executionTasks, fixSteps]);
+  }, [messages, currentAssistantMessage, agentPhase, executionTasks, fixSteps, followUpSteps]);
 
   const showDesignProgress = agentPhase === 'designing';
   const showOverview = agentPhase === 'awaiting_approval' && planOverview;
   const showTaskProgress = (agentPhase === 'executing' || agentPhase === 'complete') && executionTasks.length > 0;
   const showFixProgress = fixSteps.length > 0 && isStreaming;
-  const showStreamingMessage = isStreaming && currentAssistantMessage && !showDesignProgress && !showOverview && !showTaskProgress && !showFixProgress;
-  const showPhaseIndicator = agentPhase === 'classifying' || agentPhase === 'planning';
+  const showFollowUpProgress = followUpSteps.length > 0 && isStreaming;
+  const showStreamingMessage = isStreaming && currentAssistantMessage && !showDesignProgress && !showOverview && !showTaskProgress && !showFixProgress && !showFollowUpProgress;
+  const showPhaseIndicator = agentPhase === 'classifying' || agentPhase === 'planning' || (agentPhase === 'exploring' && followUpSteps.length === 0);
 
   return (
     <div style={{
@@ -425,6 +427,17 @@ export function ChatPanel() {
 
         {/* Fix progress */}
         {showFixProgress && <FixProgressLive steps={fixSteps} content={currentAssistantMessage} />}
+
+        {/* Follow-up exploration progress */}
+        {showFollowUpProgress && (
+          <FollowUpProgress
+            steps={followUpSteps}
+            answer={currentAssistantMessage || undefined}
+            filesChanged={actions.filter((a) => a.type === 'file' && a.path).map((a) => a.path!)}
+            diffs={followUpDiffs.length > 0 ? followUpDiffs : undefined}
+            isLive
+          />
+        )}
 
         {/* Streaming message (follow-up flow) */}
         {showStreamingMessage && (

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { Message, Action, WSMessage, AIModel, AgentPhase, AgentCard, PlanOverview, ExecutionTask, ProjectSummary, FixStep } from '../types';
+import type { Message, Action, WSMessage, AIModel, AgentPhase, AgentCard, PlanOverview, ExecutionTask, ProjectSummary, FixStep, FollowUpStep, FileDiff } from '../types';
 import { getChatSocket } from '../services/websocket';
 import { useSessionStore } from './session';
 import { useFilesStore } from './files';
@@ -63,6 +63,8 @@ interface ChatState {
   planOverview: PlanOverview | null;
   executionTasks: ExecutionTask[];
   fixSteps: FixStep[];
+  followUpSteps: FollowUpStep[];
+  followUpDiffs: FileDiff[];
   designProgress: { architecture: string | null; ux: string | null };
   projectSummary: ProjectSummary | null;
   // Package integration
@@ -100,6 +102,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
   planOverview: null,
   executionTasks: [],
   fixSteps: [],
+  followUpSteps: [],
+  followUpDiffs: [],
   designProgress: { architecture: null, ux: null },
   projectSummary: null,
   selectedPackage: null,
@@ -284,6 +288,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
       agentPhase: 'idle',
       planOverview: null,
       executionTasks: [],
+      followUpSteps: [],
+      followUpDiffs: [],
       designProgress: { architecture: null, ux: null },
     }));
 
@@ -376,6 +382,44 @@ export const useChatStore = create<ChatState>((set, get) => ({
           }
           break;
         }
+        case 'followup_step': {
+          set((state) => {
+            if (msg.status === 'running') {
+              const stepId = generateId();
+              return {
+                followUpSteps: [
+                  ...state.followUpSteps,
+                  {
+                    id: stepId,
+                    tool: msg.tool as FollowUpStep['tool'],
+                    args: msg.args,
+                    status: 'running',
+                    iteration: msg.iteration,
+                  },
+                ],
+              };
+            } else {
+              // Update the last running step for this tool+iteration
+              const steps = [...state.followUpSteps];
+              const idx = steps.findLastIndex(
+                (s) => s.tool === msg.tool && s.iteration === msg.iteration && s.status === 'running'
+              );
+              if (idx >= 0) {
+                steps[idx] = {
+                  ...steps[idx],
+                  status: msg.status as FollowUpStep['status'],
+                  resultPreview: msg.result_preview,
+                };
+              }
+              return { followUpSteps: steps };
+            }
+          });
+          break;
+        }
+        case 'followup_diffs': {
+          set({ followUpDiffs: msg.diffs });
+          break;
+        }
         case 'text': {
           set((state) => ({
             currentAssistantMessage: state.currentAssistantMessage + msg.content,
@@ -439,8 +483,27 @@ export const useChatStore = create<ChatState>((set, get) => ({
           const state = get();
           const newMessages: Message[] = [];
 
-          // Save streaming text as a message (follow-up flow)
-          if (state.currentAssistantMessage) {
+          // Save follow-up progress card
+          if (state.followUpSteps.length > 0) {
+            const filesChanged = state.actions
+              .filter((a) => a.type === 'file' && a.path)
+              .map((a) => a.path!);
+            newMessages.push({
+              id: generateId(),
+              role: 'assistant',
+              content: state.currentAssistantMessage,
+              actions: state.actions.length > 0 ? [...state.actions] : undefined,
+              timestamp: Date.now(),
+              agentCard: {
+                type: 'followup_progress',
+                steps: [...state.followUpSteps],
+                answer: state.currentAssistantMessage || undefined,
+                filesChanged: filesChanged.length > 0 ? filesChanged : undefined,
+                diffs: state.followUpDiffs.length > 0 ? [...state.followUpDiffs] : undefined,
+              },
+            });
+          } else if (state.currentAssistantMessage) {
+            // Save streaming text as a message (follow-up flow)
             newMessages.push({
               id: generateId(),
               role: 'assistant',
@@ -473,6 +536,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
             agentPhase: 'idle',
             planOverview: null,
             executionTasks: [],
+            followUpSteps: [],
+            followUpDiffs: [],
           }));
           socket.offMessage(handler);
           activeHandler = null;
@@ -590,14 +655,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
           package: packageInfo,
         };
       });
-      set({ messages, currentAssistantMessage: '', actions: [], fixSteps: [], error: null, agentPhase: 'idle', planOverview: null, executionTasks: [] });
+      set({ messages, currentAssistantMessage: '', actions: [], fixSteps: [], followUpSteps: [], followUpDiffs: [], error: null, agentPhase: 'idle', planOverview: null, executionTasks: [] });
     } catch (err) {
       console.error('Failed to load chat history:', err);
     }
   },
 
   clearMessages() {
-    set({ messages: [], currentAssistantMessage: '', actions: [], fixSteps: [], error: null, agentPhase: 'idle', planOverview: null, executionTasks: [] });
+    set({ messages: [], currentAssistantMessage: '', actions: [], fixSteps: [], followUpSteps: [], followUpDiffs: [], error: null, agentPhase: 'idle', planOverview: null, executionTasks: [] });
   },
 
   clearError() {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -23,7 +23,8 @@ export type AgentCard =
   | { type: 'project_summary'; summary: ProjectSummary }
   | { type: 'error_fix_request'; errorMessage: string; errorFile?: string; errorLine?: number; errorStack?: string }
   | { type: 'fix_progress'; steps: FixStep[] }
-  | { type: 'package_fetched'; packageId: string; packageName: string; dataSchema: string; relevantFields?: string };
+  | { type: 'package_fetched'; packageId: string; packageName: string; dataSchema: string; relevantFields?: string }
+  | { type: 'followup_progress'; steps: FollowUpStep[]; answer?: string; filesChanged?: string[]; diffs?: FileDiff[] };
 
 export interface Action {
   type: 'file' | 'shell';
@@ -77,6 +78,7 @@ export type AgentPhase =
   | 'awaiting_approval'
   | 'executing'
   | 'fixing'
+  | 'exploring'
   | 'complete';
 
 // User-facing plan overview (shown during approval)
@@ -112,6 +114,20 @@ export interface FixStep {
   message: string;
 }
 
+export interface FileDiff {
+  path: string;
+  diff: string;
+}
+
+export interface FollowUpStep {
+  id: string;
+  tool: 'grep' | 'glob' | 'read_file' | 'write_file' | 'edit_file';
+  args: Record<string, string>;
+  status: 'running' | 'completed' | 'failed';
+  resultPreview?: string;
+  iteration: number;
+}
+
 export type WSMessage =
   | { type: 'message'; content: string; model?: string; packageId?: number }
   | { type: 'text'; content: string }
@@ -129,4 +145,6 @@ export type WSMessage =
   | { type: 'fix_step'; step: 'discover' | 'generate' | 'write' | 'validate' | 'retry'; status: 'running' | 'completed' | 'failed'; message: string }
   | { type: 'fix_error'; error_message: string; error_file?: string; error_line?: number; error_stack?: string; model?: string }
   | { type: 'package_fetched'; package_id: string; package_name: string; data_schema: string; relevant_fields?: string }
-  | { type: 'package_error'; message: string };
+  | { type: 'package_error'; message: string }
+  | { type: 'followup_step'; tool: string; args: Record<string, string>; status: string; result_preview?: string; iteration: number }
+  | { type: 'followup_diffs'; diffs: FileDiff[] };


### PR DESCRIPTION
Replace the single-turn _simple_flow for follow-up messages with a ReACT-loop agent that can explore the codebase (grep, glob, read_file) and make targeted edits (write_file, edit_file) via function calling. The agent gets immediate feedback on failed edits and can retry naturally within the same loop.

Backend:
- New FollowUpAgent class with @observe-decorated methods and 5 tools
- Deterministic classifier: first message = new project, subsequent = follow-up
- Extended ActionParser with on_edit_action for search/replace blocks
- Added complete_chat_with_tools() to provider for function calling support
- Unified diffs computed and sent via WS for live + persisted rendering

Frontend:
- Unified FollowUpProgress component for both live and persisted cards
- GitHub-style collapsible diff viewer with red/green line highlighting
- Tool step icons and present/past tense labels (Searching.../Searched for...)
- followup_step and followup_diffs WS message handling in chat store
- Added remark-gfm for markdown table rendering