### PR TITLE
refactor: complete color system — eliminate all hardcoded colors

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -75,6 +75,19 @@
   --preview-bg: #181825;
   --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
 
+  /* Brand (fixed — does not change with theme) */
+  --brand: #2bbcc4;
+
+  /* Project avatar palette */
+  --project-purple: #cba6f7;
+  --project-teal: #94e2d5;
+  --project-peach: #fab387;
+  --project-sky: #74c7ec;
+
+  /* Utility aliases */
+  --dim: var(--muted-foreground);
+  --strong: var(--surface);
+
   /* Legacy aliases (used by non-migrated components) */
   --bg: var(--background);
   --text: var(--foreground);
@@ -137,6 +150,16 @@
   --table-stripe: rgba(0, 0, 0, 0.02);
   --preview-bg: #ffffff;
 
+  /* Project avatar palette */
+  --project-purple: #7c3aed;
+  --project-teal: #0d9488;
+  --project-peach: #ea580c;
+  --project-sky: #0284c7;
+
+  /* Utility aliases */
+  --dim: var(--muted-foreground);
+  --strong: var(--muted);
+
   --bg: var(--background);
   --text: var(--foreground);
   --text-dim: var(--muted-foreground);
@@ -176,7 +199,21 @@
   --color-danger-bg: var(--danger-bg);
   --color-diff-add: var(--diff-add);
   --color-diff-remove: var(--diff-remove);
+  --color-diff-add-bg: var(--diff-add-bg);
+  --color-diff-remove-bg: var(--diff-remove-bg);
   --color-overlay: var(--overlay);
+  --color-success-bg: var(--success-bg);
+  --color-accent-bg-strong: var(--accent-bg-strong);
+  --color-accent-border: var(--accent-border);
+  --color-dropdown-header-bg: var(--dropdown-header-bg);
+  --color-dropdown-divider: var(--dropdown-divider);
+  --color-project-purple: var(--project-purple);
+  --color-project-teal: var(--project-teal);
+  --color-project-peach: var(--project-peach);
+  --color-project-sky: var(--project-sky);
+  --color-brand: var(--brand);
+  --color-dim: var(--dim);
+  --color-strong: var(--strong);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -252,12 +289,12 @@
   }
 
   ::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.12);
+    background: var(--border);
     border-radius: 3px;
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    background: rgba(255, 255, 255, 0.22);
+    background: var(--muted-foreground);
   }
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -178,7 +178,7 @@ export default function App() {
     return (
       <div className="flex flex-col items-center justify-center h-full gap-3 select-none">
         <FlowBrand size="lg" />
-        <Loader2 size={20} className="animate-spin text-[#2bbcc4]" />
+        <Loader2 size={20} className="animate-spin text-brand" />
       </div>
     );
   }

--- a/frontend/src/components/chat/ModelSelector.tsx
+++ b/frontend/src/components/chat/ModelSelector.tsx
@@ -55,7 +55,7 @@ export function ModelSelector() {
         <div className="absolute bottom-full start-0 mb-1 min-w-[260px] max-h-80 overflow-auto bg-popover border border-border rounded-lg shadow-[var(--shadow-lg)] z-40">
           {Object.entries(grouped).map(([provider, providerModels]) => (
             <div key={provider}>
-              <div className="px-2.5 py-1.5 text-[11px] uppercase tracking-wider text-muted-foreground border-b border-[var(--dropdown-divider)] bg-[var(--dropdown-header-bg)]">
+              <div className="px-2.5 py-1.5 text-[11px] uppercase tracking-wider text-muted-foreground border-b border-dropdown-divider bg-dropdown-header-bg">
                 {provider}
               </div>
               {providerModels.map((m) => {
@@ -65,8 +65,8 @@ export function ModelSelector() {
                     key={m.id}
                     type="button"
                     onClick={() => { setSelectedModel(m.id); setOpen(false); }}
-                    className={`w-full flex items-center gap-2 px-2.5 py-1.5 text-xs text-left cursor-pointer border-b border-[var(--dropdown-divider)] ${
-                      isActive ? 'bg-[var(--accent-bg-strong)]' : 'hover:bg-muted/50'
+                    className={`w-full flex items-center gap-2 px-2.5 py-1.5 text-xs text-left cursor-pointer border-b border-dropdown-divider ${
+                      isActive ? 'bg-accent-bg-strong' : 'hover:bg-muted/50'
                     }`}
                   >
                     <Check size={14} className={`shrink-0 text-primary ${isActive ? 'opacity-100' : 'opacity-0'}`} />

--- a/frontend/src/components/chat/cards/DiffBlock.tsx
+++ b/frontend/src/components/chat/cards/DiffBlock.tsx
@@ -33,10 +33,10 @@ export function DiffBlock({ fileDiff }: { fileDiff: FileDiff }) {
             let bgClass = '';
             let textClass = 'text-muted-foreground';
             if (line.startsWith('+') && !line.startsWith('+++')) {
-              bgClass = 'bg-[var(--diff-add-bg)]';
+              bgClass = 'bg-diff-add-bg';
               textClass = 'text-diff-add';
             } else if (line.startsWith('-') && !line.startsWith('---')) {
-              bgClass = 'bg-[var(--diff-remove-bg)]';
+              bgClass = 'bg-diff-remove-bg';
               textClass = 'text-diff-remove';
             } else if (line.startsWith('@@')) {
               textClass = 'text-primary';

--- a/frontend/src/components/editor/EditorPanel.tsx
+++ b/frontend/src/components/editor/EditorPanel.tsx
@@ -208,7 +208,7 @@ export function EditorPanel() {
                 </>
               ) : (
                 <>
-                  <Check size={10} className="text-green-400" /> {t('editor.saved')}
+                  <Check size={10} className="text-success" /> {t('editor.saved')}
                 </>
               )}
             </div>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -116,10 +116,14 @@ export function AppShell() {
 
   // Project colors + initials for icon rail
   const PROJECT_COLORS = [
-    'bg-[#89b4fa]/20 text-[#89b4fa]', 'bg-[#a6e3a1]/20 text-[#a6e3a1]',
-    'bg-[#f9e2af]/20 text-[#f9e2af]', 'bg-[#cba6f7]/20 text-[#cba6f7]',
-    'bg-[#f38ba8]/20 text-[#f38ba8]', 'bg-[#94e2d5]/20 text-[#94e2d5]',
-    'bg-[#fab387]/20 text-[#fab387]', 'bg-[#74c7ec]/20 text-[#74c7ec]',
+    'bg-primary/20 text-primary',
+    'bg-success/20 text-success',
+    'bg-warning/20 text-warning',
+    'bg-project-purple/20 text-project-purple',
+    'bg-destructive/20 text-destructive',
+    'bg-project-teal/20 text-project-teal',
+    'bg-project-peach/20 text-project-peach',
+    'bg-project-sky/20 text-project-sky',
   ];
 
   function getColor(name: string) {
@@ -144,7 +148,7 @@ export function AppShell() {
   const IconRail = () => (
     <div className="flex flex-col items-center h-full py-2 gap-1">
       <button onClick={() => setSidebarPinned(true)} title={t('sidebar.expandSidebar')} className="mb-1 shrink-0">
-        <FlowLogo size={18} className="text-[#2bbcc4]" />
+        <FlowLogo size={18} className="text-brand" />
       </button>
       <div className="w-8 h-px bg-border shrink-0" />
       <div className="flex-1 flex flex-col items-center gap-1.5 py-1 overflow-hidden">

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -21,14 +21,14 @@ type SidebarProps = {
 
 // Stable color per project based on name hash
 const PROJECT_COLORS = [
-  'bg-[#89b4fa]/20 text-[#89b4fa]',   // blue
-  'bg-[#a6e3a1]/20 text-[#a6e3a1]',   // green
-  'bg-[#f9e2af]/20 text-[#f9e2af]',   // yellow
-  'bg-[#cba6f7]/20 text-[#cba6f7]',   // purple
-  'bg-[#f38ba8]/20 text-[#f38ba8]',   // pink
-  'bg-[#94e2d5]/20 text-[#94e2d5]',   // teal
-  'bg-[#fab387]/20 text-[#fab387]',   // peach
-  'bg-[#74c7ec]/20 text-[#74c7ec]',   // sky
+  'bg-primary/20 text-primary',
+  'bg-success/20 text-success',
+  'bg-warning/20 text-warning',
+  'bg-project-purple/20 text-project-purple',
+  'bg-destructive/20 text-destructive',
+  'bg-project-teal/20 text-project-teal',
+  'bg-project-peach/20 text-project-peach',
+  'bg-project-sky/20 text-project-sky',
 ];
 
 function getProjectColor(name: string) {

--- a/frontend/src/components/terminal/Console.tsx
+++ b/frontend/src/components/terminal/Console.tsx
@@ -8,16 +8,16 @@ import { Trash2 } from 'lucide-react';
 
 const LEVEL_COLORS: Record<ConsoleLevel, string> = {
   log: 'text-foreground',
-  info: 'text-blue-400',
-  warn: 'text-yellow-400',
-  error: 'text-red-400',
+  info: 'text-primary',
+  warn: 'text-warning',
+  error: 'text-destructive',
 };
 
 const LEVEL_BG: Record<ConsoleLevel, string> = {
   log: '',
   info: '',
-  warn: 'bg-yellow-500/5',
-  error: 'bg-red-500/5',
+  warn: 'bg-warning/10',
+  error: 'bg-destructive/10',
 };
 
 function resolveSourceLine(file: string, args: string[]): Promise<number | undefined> {

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -8,7 +8,7 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default: 'bg-primary/15 text-primary border border-primary/25',
-        accent: 'bg-accent-bg text-foreground border border-[var(--accent-border)]',
+        accent: 'bg-accent-bg text-foreground border border-accent-border',
         muted: 'bg-muted text-muted-foreground',
         success: 'bg-success/15 text-success',
         destructive: 'bg-destructive/15 text-destructive',

--- a/frontend/src/components/ui/flow-logo.tsx
+++ b/frontend/src/components/ui/flow-logo.tsx
@@ -36,9 +36,9 @@ export function FlowBrand({ size = 'md', className }: FlowBrandProps) {
 
   return (
     <div className={`flex items-center ${config.gap} ${className ?? ''}`}>
-      <FlowLogo size={config.icon} className="text-[#2bbcc4]" />
+      <FlowLogo size={config.icon} className="text-brand" />
       <span className={`font-bold tracking-tight ${config.text}`}>
-        <span className="text-[#2bbcc4]">FLOW</span>
+        <span className="text-brand">FLOW</span>
         <span className="text-foreground">{suffix}</span>
       </span>
     </div>


### PR DESCRIPTION
## Summary

- **Register 15 missing CSS variables** in `@theme inline` so they resolve as clean Tailwind classes (`bg-diff-add-bg`, `border-accent-border`, `bg-accent-bg-strong`, etc.) instead of the awkward `bg-[var(--...)]` escape syntax
- **Add `--brand` token** (`#2bbcc4`, the FlowBolt logo teal) and replace all 4 `text-[#2bbcc4]` hardcodes in `App.tsx`, `flow-logo.tsx`, and `AppShell.tsx`
- **Add 4 project palette tokens** (`--project-purple/teal/peach/sky`) with correct light/dark values; replace the 8-entry hardcoded hex `PROJECT_COLORS` arrays in both `Sidebar.tsx` and `AppShell.tsx` with semantic token classes
- **Add `--dim` / `--strong` utility aliases** so existing `text-dim` and `bg-strong` classes actually resolve (they were no-ops before)
- **Fix theme-breaking scrollbar colors** — `rgba(255,255,255,0.12/0.22)` hardcodes replaced with `var(--border)` / `var(--muted-foreground)` so they adapt correctly in light theme
- **Replace raw Tailwind palette classes** (`text-blue/green/red/yellow-400`, `bg-red/yellow-500/5`) in `Console.tsx` and `EditorPanel.tsx` with semantic tokens (`text-primary`, `text-success`, `text-destructive`, `text-warning`, `bg-warning/10`, `bg-destructive/10`)

## What prompted this

Full audit of all client-side color usage. The system was ~95% token-based already; this closes the remaining gaps so every color adapts correctly to both themes and no component bypasses the design system.

## Files changed

| File | Change |
|---|---|
| `frontend/src/App.css` | +`--brand`, +4 project tokens, +`--dim`/`--strong`, +15 `@theme inline` registrations, fix scrollbar |
| `frontend/src/App.tsx` | `text-[#2bbcc4]` → `text-brand` |
| `frontend/src/components/ui/flow-logo.tsx` | `text-[#2bbcc4]` → `text-brand` (×2) |
| `frontend/src/components/layout/AppShell.tsx` | `text-[#2bbcc4]` → `text-brand`, replace `PROJECT_COLORS` hex array |
| `frontend/src/components/layout/Sidebar.tsx` | Replace `PROJECT_COLORS` hex array with semantic tokens |
| `frontend/src/components/chat/cards/DiffBlock.tsx` | `bg-[var(--diff-add/remove-bg)]` → `bg-diff-add/remove-bg` |
| `frontend/src/components/chat/ModelSelector.tsx` | 3 arbitrary `var()` class references → token classes |
| `frontend/src/components/ui/badge.tsx` | `border-[var(--accent-border)]` → `border-accent-border` |
| `frontend/src/components/terminal/Console.tsx` | Raw Tailwind colors → semantic tokens |
| `frontend/src/components/editor/EditorPanel.tsx` | `text-green-400` → `text-success` |

## Reviewer notes

- `FileTree.tsx` file-type icon hex colors are intentionally left as-is — they are VS Code-style fixed semantic colors for file types (JSON=gold, TS=blue, etc.), not theme colors
- `color-mix()` patterns in `DataSourcesFetchedCard` are left as-is — intentional dynamic tints
- The `PROJECT_COLORS` order is preserved exactly to maintain stable per-project color assignment (hash-based)

🤖 Generated with [Claude Code](https://claude.com/claude-code)