### PR TITLE
2/4 — Dev watch scoping and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+.pnpm-store/
 __pycache__/
 *.pyc
 .venv/

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,6 +15,18 @@ export default defineConfig({
     },
   },
   server: {
+    watch: {
+      ignored: [
+        '**/node_modules/**',
+        '**/dist/**',
+        '**/coverage/**',
+        '**/test-results/**',
+        '**/playwright-report/**',
+        '**/backend/**',
+        '**/mocks/**',
+        '**/.git/**',
+      ],
+    },
     proxy: {
       '/api': {
         target: 'http://localhost:8000',

--- a/mocks/flapi-mock/nodemon.json
+++ b/mocks/flapi-mock/nodemon.json
@@ -1,0 +1,10 @@
+{
+  "watch": ["."],
+  "ext": "js,json,html,py",
+  "ignore": [
+    "node_modules/**",
+    "**/node_modules/**",
+    "package-lock.json",
+    "pnpm-lock.yaml"
+  ]
+}


### PR DESCRIPTION
## Summary
**PR 2/4** — Dev watch scoping and gitignore (merge after #99 ✅).

- Add `.pnpm-store/` to `.gitignore`
- Keep `CLAUDE.md` ignored (unchanged from main)
- Scope Vite watcher to frontend-only paths
- Add `nodemon.json` for flapi-mock watch isolation

**1 commit** · base: `main`

## Merge order
#99 ✅ → **this PR** → #105 → #96 / #106

## Test plan
- [ ] `make dev-backend` / `dev-frontend` / `dev-mocks` in separate terminals
- [ ] `.pnpm-store` not tracked by git
- [ ] `CLAUDE.md` remains gitignored