### PR TITLE
Fix chat focus shortcut conflict with editor

### DIFF
--- a/frontend/src/components/chat/PromptInput.tsx
+++ b/frontend/src/components/chat/PromptInput.tsx
@@ -47,14 +47,10 @@ export function PromptInput() {
   const disabled = isBusy || !projectId;
   const canSend = !!value.trim() && !disabled;
 
-  // Global keyboard shortcut: Cmd+K or / to focus
+  // Global keyboard shortcut: Cmd+K to focus chat
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-        e.preventDefault();
-        textareaRef.current?.focus();
-      }
-      if (e.key === '/' && document.activeElement?.tagName !== 'TEXTAREA' && document.activeElement?.tagName !== 'INPUT') {
         e.preventDefault();
         textareaRef.current?.focus();
       }


### PR DESCRIPTION
## Summary
- Remove the global `/` shortcut that focused the chat input, which conflicted with typing in the Monaco editor and other contexts.
- Keep `Cmd+K` / `Ctrl+K` as the sole keyboard shortcut to focus the chat input.

Split from #92 per review feedback from @88roy88.

## Test plan
- [ ] Press `/` in the Monaco editor — chat input should not steal focus
- [ ] Press `Cmd+K` from anywhere — chat input should focus

Made with [Cursor](https://cursor.com)