### PR TITLE
1/4 — Consolidate dev Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,51 @@
 .PHONY: dev dev-backend dev-frontend dev-mocks kill-ports build run install stop
 
 # Local dev: mock (flapi-mock), FastAPI, Vite — free these before (re)starting
-DEV_PORTS := 4000 8000 5173
+DEV_PORT_BACKEND := 8000
+DEV_PORT_FRONTEND := 5173
+DEV_PORT_MOCKS := 6001
+DEV_PORTS := $(DEV_PORT_BACKEND) $(DEV_PORT_FRONTEND) $(DEV_PORT_MOCKS)
 
 # All three at once: backend blocks forever if run sequentially, so we use parallel sub-makes (GNU Make).
 # Single service: make dev-backend | make dev-frontend | make dev-mocks
-dev:
+dev: kill-ports
 	+$(MAKE) -j3 dev-backend dev-frontend dev-mocks
 
 ifeq ($(OS),Windows_NT)
-# taskkill /T = whole tree; unique PIDs (IPv4+IPv6 duplicate rows); brief sleep so handles drop before uv
 kill-ports:
-	@powershell -NoProfile -Command "$$ports = @(4000,8000,5173); $$seen = @{}; foreach ($$p in $$ports) { Get-NetTCPConnection -LocalPort $$p -State Listen -ErrorAction SilentlyContinue | ForEach-Object { $$id = [int]$$_.OwningProcess; if ($$id -gt 0 -and -not $$seen.ContainsKey($$id)) { $$seen[$$id] = $$true; Write-Host ('Stopping process tree PID ' + $$id + ' (port ' + $$p + ')'); & taskkill /PID $$id /F /T 2>$$null } } }; Start-Sleep -Seconds 2"
+	@$(MAKE) -s kill-port-$(DEV_PORT_BACKEND) kill-port-$(DEV_PORT_FRONTEND) kill-port-$(DEV_PORT_MOCKS)
+
+kill-port-%:
+	@powershell -NoProfile -Command "$$p = $*; $$seen = @{}; Get-NetTCPConnection -LocalPort $$p -State Listen -ErrorAction SilentlyContinue | ForEach-Object { $$id = [int]$$_.OwningProcess; if ($$id -gt 0 -and -not $$seen.ContainsKey($$id)) { $$seen[$$id] = $$true; Write-Host ('Stopping process tree PID ' + $$id + ' (port ' + $$p + ')'); & taskkill /PID $$id /F /T 2>$$null } }"
 else
 kill-ports:
 	@for port in $(DEV_PORTS); do \
-		pids=$$(lsof -ti :$$port 2>/dev/null || true); \
-		if [ -n "$$pids" ]; then \
-			echo "Stopping PID(s) $$pids on port $$port"; \
-			kill -9 $$pids 2>/dev/null || true; \
-		fi; \
+		$(MAKE) -s kill-port-$$port; \
 	done
+
+kill-port-%:
+	@pids=$$(lsof -ti :$* 2>/dev/null || true); \
+	if [ -n "$$pids" ]; then \
+		echo "Stopping PID(s) $$pids on port $*"; \
+		kill -9 $$pids 2>/dev/null || true; \
+	fi
 endif
 
 # --no-sync avoids uv reinstalling entry points (dev.exe) on every run — fixes Windows file-in-use (os error 32)
 # Use --app-dir src because backend uses src-layout (flow44 package lives under backend/src).
-dev-backend: kill-ports
-	cd backend && uv run --no-sync python -m uvicorn --app-dir src flow44.main:app --host 0.0.0.0 --port 8000 --reload --reload-dir src/flow44 --log-level info
+dev-backend: kill-port-$(DEV_PORT_BACKEND)
+	cd backend && uv run --no-sync python -m uvicorn --app-dir src flow44.main:app --host 0.0.0.0 --port $(DEV_PORT_BACKEND) --reload --reload-dir src/flow44 --reload-exclude '**/__pycache__/**' --reload-exclude '**/*.pyc' --log-level info
 
-dev-frontend: kill-ports
-	cd frontend && pnpm dev
+dev-frontend: kill-port-$(DEV_PORT_FRONTEND)
+	cd frontend && pnpm dev -- --port $(DEV_PORT_FRONTEND)
 
 # server.js lives under mocks/flapi-mock (FLAPI / package mock)
-dev-mocks: kill-ports
-	cd mocks/flapi-mock && pnpm install && pnpm dev
+dev-mocks: kill-port-$(DEV_PORT_MOCKS)
+	cd mocks/flapi-mock && pnpm install && MOCK_PORT=$(DEV_PORT_MOCKS) pnpm dev
 
-# Install dependencies
+# Install dependencies (also installs Husky git hooks)
 install:
+	pnpm install
 	cd frontend && pnpm install
 	cd backend && uv sync
 


### PR DESCRIPTION
## Summary
Dev Makefile only — **merge first**.

- Ports: backend `8000`, frontend `5173`, mocks `6001`
- Per-service `kill-port-*` (no cross-service kills)
- Uvicorn reload excludes, `MOCK_PORT`, frontend `--port`
- Root `pnpm install` for Husky hooks

**1 commit** · independent tree

## Test plan
- [ ] `make dev` — all services start on correct ports
- [ ] Run each service in a separate terminal without killing siblings