### PR TITLE
Add Swagger docs and README to flapi-mock service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+.pnpm-store/
 __pycache__/
 *.pyc
 .venv/

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This launches three processes in parallel:
 | ------------------------ | ----------------------------------------- | --------------------- |
 | Backend (FastAPI)        | `uv run uvicorn flow44.main:app --reload` | http://localhost:8000 |
 | Frontend (Vite)          | `pnpm dev`                                | http://localhost:5173 |
-| Mock server (flapi-mock) | `pnpm dev`                                | http://localhost:4000 |
+| Mock server (flapi-mock) | `pnpm dev`                                | http://localhost:6001 |
 
 Or start each service individually:
 
@@ -75,7 +75,7 @@ make dev-frontend   # Vite only
 make dev-mocks      # flapi-mock only
 ```
 
-> `make dev` (and each individual target) automatically kills any processes occupying ports **4000**, **8000**, and **5173** before starting.
+> `make dev` (and each individual target) automatically kills any processes occupying ports **6001**, **8000**, and **5173** before starting.
 
 **No make:** open three separate terminals and run one command in each:
 
@@ -96,6 +96,19 @@ pnpm dev
 cd mocks/flapi-mock
 pnpm install
 pnpm dev
+```
+
+Mock API docs (Swagger UI): http://localhost:6001/docs  
+OpenAPI spec: http://localhost:6001/openapi.json
+
+See [`mocks/flapi-mock/README.md`](mocks/flapi-mock/README.md) for endpoints, stub data, env vars, and troubleshooting.
+
+The separate **model mock** (OpenAI-compatible completions for tests) is a FastAPI app under `mocks/flapi-mock/model_mock/`. Run it locally with uvicorn and browse `/docs`:
+
+```bash
+cd mocks/flapi-mock
+uv run uvicorn model_mock.app:app --reload --port 6002
+# Swagger UI: http://localhost:6002/docs
 ```
 
 ---

--- a/mocks/flapi-mock/.gitignore
+++ b/mocks/flapi-mock/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.pnpm-store/
+*.log

--- a/mocks/flapi-mock/.npmrc
+++ b/mocks/flapi-mock/.npmrc
@@ -1,0 +1,1 @@
+store-dir=node_modules/.pnpm-store

--- a/mocks/flapi-mock/README.md
+++ b/mocks/flapi-mock/README.md
@@ -1,0 +1,196 @@
+# flapi-mock
+
+Development mock server for FLAPI package search/run APIs, legacy Visualis client endpoints, and mock SSO. Used by the FlowBolt backend and frontend during local development.
+
+Default URL: **http://localhost:6001**
+
+---
+
+## Quick start
+
+```bash
+pnpm install
+pnpm dev          # nodemon with reload
+# or
+pnpm start        # node server.js (no reload)
+```
+
+From the repo root:
+
+```bash
+make dev-mocks
+```
+
+Smoke test (server must be running):
+
+```bash
+pnpm test
+# or against another base URL:
+node test-mock.js http://localhost:6001
+```
+
+---
+
+## API documentation
+
+| Resource | URL |
+| -------- | --- |
+| Swagger UI | http://localhost:6001/docs |
+| OpenAPI JSON | http://localhost:6001/openapi.json |
+| OpenAPI source | [`openapi.yaml`](openapi.yaml) |
+
+Update `openapi.yaml` when adding or changing routes, then restart the server.
+
+---
+
+## What it provides
+
+### FLAPI (backend integration)
+
+Used by `FlapiClient` in `backend/src/flow44/integrations/flapi_api.py`.
+
+| Method | Path | Notes |
+| ------ | ---- | ----- |
+| GET | `/package/v1/search/{partial}` | Autocomplete by name or lookup by numeric ID |
+| POST | `/package/{packageId}` | Run package (v1) |
+| POST | `/package/v3/{packageId}` | Run package (v3, used by backend) |
+
+Legacy aliases under `/api/flapi/*` call the same handlers.
+
+**Auth:** FLAPI routes require a non-empty `Authorization` header. Any token value is accepted in the mock.
+
+### Client / agent (legacy Visualis)
+
+| Method | Path | Purpose |
+| ------ | ---- | ------- |
+| GET | `/api/config` | Client config (`baseUrl`, `iframeDataEvent`) |
+| GET | `/api/models` | Available mock models |
+| GET | `/api/libs` | Injectable library catalog |
+| POST | `/api/generate` | Generate HTML snippet from cube data |
+| POST | `/api/feedback` | Regenerate snippet with feedback |
+| POST | `/api/model/prompt` | Mock model prompt assembly |
+| GET | `/api/snippets/{runId}.html` | Fetch stored HTML snippet |
+
+### Utility
+
+| Method | Path | Purpose |
+| ------ | ---- | ------- |
+| GET | `/health` | Health check (`{ ok: true, mock: true }`) |
+| GET | `/sso` | Mock SSO login page |
+| GET | `/libs/*` | Static library assets |
+
+---
+
+## Stub package IDs
+
+POST run endpoints return different cube datasets depending on `packageId`:
+
+| ID | Dataset |
+| -- | ------- |
+| `1` | Default sales cubes |
+| `3` | Intelligence briefing |
+| `4` | People & photos |
+| `5` | Real-time server dashboard (metrics refresh each call) |
+| `6` | People Hebrew names |
+| `7` | E-commerce analytics |
+| `8` | HR & workforce |
+| `9` | Logistics & shipping |
+| `10` | Phone devices & specs |
+| `11` | Phone call records |
+| `12` | Phone repairs & warranty |
+| `13` | Phone market analytics |
+| other | Default sales cubes |
+
+Stub data lives in [`stubData.js`](stubData.js).
+
+---
+
+## Environment variables
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `MOCK_PORT` | `6001` | HTTP listen port |
+| `BASE_URL` | `http://localhost:{MOCK_PORT}` | Base URL returned in `/api/config` and used for library injection |
+| `IFRAME_DATA_EVENT` | `IFRAME_DATA` | PostMessage event name injected into generated HTML |
+| `LIBS_ROOT` | `../libs` | Directory served at `/libs` |
+
+---
+
+## FlowBolt integration
+
+**Backend** — set in `backend/.env`:
+
+```env
+AIB_FLAPI_BASE_URL=http://localhost:6001
+```
+
+**Frontend** — mock SSO in `frontend/.env.development`:
+
+```env
+VITE_AUTH_PROVIDER_URL=http://localhost:6001/sso
+```
+
+**Docker Compose** — the `flapi-mock` service exposes port `6001` and the backend uses `http://flapi-mock:6001`.
+
+---
+
+## Model mock (OpenAI-compatible)
+
+A separate FastAPI app for deterministic LLM completions in tests:
+
+```
+model_mock/
+  app.py          # POST /v1/chat/completions, POST /v1/completions
+  ...
+```
+
+Run locally:
+
+```bash
+cd mocks/flapi-mock
+uv run uvicorn model_mock.app:app --reload --port 6002
+```
+
+Swagger UI: http://localhost:6002/docs
+
+Optional env vars: `MOCK_HTML_RESPONSE`, `MOCK_ECHO_USER=1`.
+
+Python tests:
+
+```bash
+cd mocks/flapi-mock
+uv run pytest tests/test_model_mock.py
+```
+
+---
+
+## Project layout
+
+```
+flapi-mock/
+  server.js         # Express app
+  openapi.yaml      # OpenAPI spec (Swagger source)
+  stubData.js       # Cube and search stub data
+  errorBody.js      # Standard error response helper
+  test-mock.js      # CLI smoke tests
+  public/           # Static assets (SSO login page)
+  model_mock/       # FastAPI OpenAI-compatible mock
+  tests/            # Python tests for model_mock
+```
+
+---
+
+## Troubleshooting
+
+**Port already in use (`EADDRINUSE` on 6001)**
+
+```bash
+lsof -nP -iTCP:6001 -sTCP:LISTEN
+kill <PID>
+```
+
+Then restart with `pnpm dev`.
+
+**FLAPI calls return 401**
+
+Send any non-empty `Authorization` header, e.g. `Authorization: Bearer mock-token`.

--- a/mocks/flapi-mock/model_mock/app.py
+++ b/mocks/flapi-mock/model_mock/app.py
@@ -6,10 +6,11 @@ from __future__ import annotations
 
 import os
 import time
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field
 
 app = FastAPI(title="Model Mock", description="OpenAI-compatible completions mock")
 
@@ -17,6 +18,69 @@ app = FastAPI(title="Model Mock", description="OpenAI-compatible completions moc
 # Default includes <Library:Lodash /> placeholder and LIBRARIES_USED line for server injection tests.
 DEFAULT_HTML = """<!DOCTYPE html><html><head><meta charset="utf-8"><Library:Lodash /></head><body><p>Generated chart</p></body></html>
 LIBRARIES_USED: lodash"""
+
+
+class ChatMessage(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    role: str
+    content: str | list[dict[str, Any]] | None = None
+
+
+class ChatCompletionsRequest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    messages: list[ChatMessage] = Field(default_factory=list)
+    model: str = "mock-model"
+
+
+class CompletionsRequest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    prompt: str | list[str] | None = None
+    model: str = "mock-model"
+
+
+class ChatChoiceMessage(BaseModel):
+    role: Literal["assistant"] = "assistant"
+    content: str
+
+
+class ChatChoice(BaseModel):
+    index: int = 0
+    message: ChatChoiceMessage
+    finish_reason: Literal["stop"] = "stop"
+
+
+class TextChoice(BaseModel):
+    index: int = 0
+    text: str
+    logprobs: None = None
+    finish_reason: Literal["stop"] = "stop"
+
+
+class Usage(BaseModel):
+    prompt_tokens: int = 10
+    completion_tokens: int = 20
+    total_tokens: int = 30
+
+
+class ChatCompletionsResponse(BaseModel):
+    id: str
+    object: Literal["chat.completion"] = "chat.completion"
+    created: int
+    model: str
+    choices: list[ChatChoice]
+    usage: Usage
+
+
+class CompletionsResponse(BaseModel):
+    id: str
+    object: Literal["text_completion"] = "text_completion"
+    created: int
+    model: str
+    choices: list[TextChoice]
+    usage: Usage
 
 
 def _get_last_user_content(messages: list[dict[str, Any]]) -> str:
@@ -33,7 +97,11 @@ def _get_last_user_content(messages: list[dict[str, Any]]) -> str:
     return ""
 
 
-@app.post("/v1/chat/completions")
+@app.post(
+    "/v1/chat/completions",
+    response_model=ChatCompletionsResponse,
+    summary="OpenAI-compatible chat completions",
+)
 async def chat_completions(request: Request) -> JSONResponse:
     """Echo or return configured HTML so agent tests are deterministic."""
     try:
@@ -43,8 +111,8 @@ async def chat_completions(request: Request) -> JSONResponse:
             status_code=400,
             content={"error": {"code": "invalid_json", "message": "Invalid JSON body"}},
         )
-    messages = body.get("messages") or []
-    model = body.get("model", "mock-model")
+    parsed = ChatCompletionsRequest.model_validate(body)
+    messages = [m.model_dump() for m in parsed.messages]
     # Return fixed HTML from env or a minimal placeholder so agent can parse it
     content = os.environ.get("MOCK_HTML_RESPONSE", DEFAULT_HTML)
     # Optional: append echoed user prompt for debugging
@@ -53,29 +121,23 @@ async def chat_completions(request: Request) -> JSONResponse:
         if last:
             content = content.rstrip() + f"\n<!-- user: {last[:200]} -->"
 
-    return JSONResponse(
-        content={
-            "id": "mock-cmpl-1",
-            "object": "chat.completion",
-            "created": int(time.time()),
-            "model": model,
-            "choices": [
-                {
-                    "index": 0,
-                    "message": {"role": "assistant", "content": content},
-                    "finish_reason": "stop",
-                }
-            ],
-            "usage": {
-                "prompt_tokens": 10,
-                "completion_tokens": 20,
-                "total_tokens": 30,
-            },
-        }
+    response = ChatCompletionsResponse(
+        id="mock-cmpl-1",
+        created=int(time.time()),
+        model=parsed.model,
+        choices=[
+            ChatChoice(message=ChatChoiceMessage(content=content)),
+        ],
+        usage=Usage(),
     )
+    return JSONResponse(content=response.model_dump())
 
 
-@app.post("/v1/completions")
+@app.post(
+    "/v1/completions",
+    response_model=CompletionsResponse,
+    summary="OpenAI-compatible legacy text completions",
+)
 async def completions(request: Request) -> JSONResponse:
     """Legacy text completions compatibility endpoint."""
     try:
@@ -86,35 +148,22 @@ async def completions(request: Request) -> JSONResponse:
             content={"error": {"code": "invalid_json", "message": "Invalid JSON body"}},
         )
 
-    model = body.get("model", "mock-model")
+    parsed = CompletionsRequest.model_validate(body)
     content = os.environ.get("MOCK_HTML_RESPONSE", DEFAULT_HTML)
-    prompt = body.get("prompt", "")
+    prompt = parsed.prompt
     if os.environ.get("MOCK_ECHO_USER") == "1" and isinstance(prompt, str) and prompt:
         content = content.rstrip() + f"\n<!-- prompt: {prompt[:200]} -->"
 
-    return JSONResponse(
-        content={
-            "id": "mock-cmpl-legacy-1",
-            "object": "text_completion",
-            "created": int(time.time()),
-            "model": model,
-            "choices": [
-                {
-                    "index": 0,
-                    "text": content,
-                    "logprobs": None,
-                    "finish_reason": "stop",
-                }
-            ],
-            "usage": {
-                "prompt_tokens": 10,
-                "completion_tokens": 20,
-                "total_tokens": 30,
-            },
-        }
+    response = CompletionsResponse(
+        id="mock-cmpl-legacy-1",
+        created=int(time.time()),
+        model=parsed.model,
+        choices=[TextChoice(text=content)],
+        usage=Usage(),
     )
+    return JSONResponse(content=response.model_dump())
 
 
-@app.get("/health")
+@app.get("/health", summary="Health check")
 async def health() -> dict[str, str]:
     return {"status": "ok"}

--- a/mocks/flapi-mock/openapi.yaml
+++ b/mocks/flapi-mock/openapi.yaml
@@ -1,0 +1,635 @@
+openapi: 3.0.3
+info:
+  title: FlowBolt FLAPI Mock
+  description: |
+    Development mock for FLAPI package search/run APIs, legacy Visualis client endpoints,
+    and mock SSO. Used by the FlowBolt backend (`FlapiClient`) and frontend auth in local dev.
+
+    **Stub package IDs** (POST run endpoints return different cube datasets):
+    - `1` — default sales cubes
+    - `3` — intelligence briefing
+    - `4` — people & photos
+    - `5` — real-time server dashboard (metrics refresh on each call)
+    - `6` — people Hebrew names
+    - `7` — e-commerce analytics
+    - `8` — HR & workforce
+    - `9` — logistics & shipping
+    - `10`–`13` — phone device/call/repair/market datasets
+    - any other ID — default sales cubes
+  version: 0.1.0
+
+servers:
+  - url: http://localhost:6001
+    description: Local dev (default MOCK_PORT)
+
+tags:
+  - name: FLAPI
+    description: FLAPI-compatible package search and run endpoints (require Authorization header)
+  - name: Client
+    description: Client configuration and library listing
+  - name: Agent
+    description: Legacy Visualis agent/generate mock endpoints
+  - name: Utility
+    description: Health checks and mock SSO
+
+components:
+  securitySchemes:
+    FlapiAuth:
+      type: apiKey
+      in: header
+      name: Authorization
+      description: Non-empty Authorization header required for FLAPI routes (any token value accepted in mock)
+
+  schemas:
+    ErrorBody:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+              example: validation_failed
+            message:
+              type: string
+              example: Query parameter "q" is required
+            details:
+              description: Optional extra error context
+
+    PackageSearchResult:
+      type: object
+      properties:
+        Id:
+          type: integer
+          example: 1
+        Logo:
+          type: string
+          example: ''
+        Name:
+          type: string
+          example: Sample Sales Package
+        Type:
+          type: string
+          enum: [Package, Template]
+          example: Package
+
+    PackageMetadata:
+      type: object
+      properties:
+        Id:
+          type: integer
+        Name:
+          type: string
+        Purpose:
+          type: string
+        Description:
+          type: string
+        UserName:
+          type: string
+        TimedPackageCount:
+          type: integer
+        Tags:
+          type: string
+          description: JSON-encoded tag array
+        Subjects:
+          type: string
+          description: JSON-encoded subjects array
+
+    PackageRunResponse:
+      type: object
+      required: [results]
+      properties:
+        results:
+          type: object
+          additionalProperties: true
+          description: Cube name → array of row objects (shape varies by package ID)
+
+    ConfigResponse:
+      type: object
+      properties:
+        baseUrl:
+          type: string
+          example: http://localhost:6001
+        iframeDataEvent:
+          type: string
+          example: IFRAME_DATA
+
+    ModelInfo:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        provider:
+          type: string
+
+    LibraryInfo:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
+          enum: [js, css, js-css]
+        files:
+          type: object
+          additionalProperties:
+            type: string
+
+    FieldExplanation:
+      type: object
+      properties:
+        fieldName:
+          type: string
+        explanation:
+          type: string
+
+    GenerateRequest:
+      type: object
+      required: [fieldExplanations, userPrompt, mainCubeName, mainCubeData]
+      properties:
+        fieldExplanations:
+          type: array
+          maxItems: 16
+          items:
+            $ref: '#/components/schemas/FieldExplanation'
+        userPrompt:
+          type: string
+        mainCubeName:
+          type: string
+        mainCubeData:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+
+    GenerateResponse:
+      type: object
+      required: [runId, htmlSnippet, librariesUsed]
+      properties:
+        runId:
+          type: string
+          example: run_1710000000000_abc123
+        htmlSnippet:
+          type: string
+          description: HTML with library injection and data listener applied
+        librariesUsed:
+          type: array
+          items:
+            type: string
+
+    FeedbackRequest:
+      type: object
+      required: [runId, feedback]
+      properties:
+        runId:
+          type: string
+        feedback:
+          type: string
+
+    ModelPromptRequest:
+      type: object
+      required: [userPrompt]
+      properties:
+        userPrompt:
+          type: string
+        systemPrompt:
+          type: string
+        structuredOutputPrompt:
+          type: string
+        restrictionsPrompt:
+          type: string
+
+    ModelPromptResponse:
+      type: object
+      properties:
+        response:
+          type: string
+        modelResponse:
+          type: object
+          properties:
+            id:
+              type: string
+            object:
+              type: string
+            choices:
+              type: array
+              items:
+                type: object
+
+    HealthResponse:
+      type: object
+      properties:
+        ok:
+          type: boolean
+          example: true
+        mock:
+          type: boolean
+          example: true
+
+paths:
+  /package/v1/search/{partial}:
+    get:
+      tags: [FLAPI]
+      summary: Search packages by partial name or numeric ID
+      security:
+        - FlapiAuth: []
+      parameters:
+        - name: partial
+          in: path
+          required: true
+          schema:
+            type: string
+          description: |
+            Autocomplete query (filters packages by name) or numeric package ID
+            (returns metadata array, empty if unknown).
+      responses:
+        '200':
+          description: Matching packages
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  oneOf:
+                    - $ref: '#/components/schemas/PackageSearchResult'
+                    - $ref: '#/components/schemas/PackageMetadata'
+        '401':
+          description: Missing Authorization header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '422':
+          description: Empty partial/query
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+
+  /api/flapi/packages/search:
+    get:
+      tags: [FLAPI]
+      summary: Search packages (legacy alias)
+      security:
+        - FlapiAuth: []
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Autocomplete query or numeric package ID
+      responses:
+        '200':
+          description: Matching packages
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  oneOf:
+                    - $ref: '#/components/schemas/PackageSearchResult'
+                    - $ref: '#/components/schemas/PackageMetadata'
+        '401':
+          description: Missing Authorization header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '422':
+          description: Missing q parameter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+
+  /package/{packageId}:
+    post:
+      tags: [FLAPI]
+      summary: Run package / data source (v1 path)
+      security:
+        - FlapiAuth: []
+      parameters:
+        - name: packageId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '200':
+          description: Stub cube results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PackageRunResponse'
+        '400':
+          description: Invalid package ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '401':
+          description: Missing Authorization header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+
+  /package/v3/{packageId}:
+    post:
+      tags: [FLAPI]
+      summary: Run package / data source (v3 path, used by backend)
+      security:
+        - FlapiAuth: []
+      parameters:
+        - name: packageId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '200':
+          description: Stub cube results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PackageRunResponse'
+        '400':
+          description: Invalid package ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '401':
+          description: Missing Authorization header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+
+  /api/flapi/packages/{packageId}/run:
+    post:
+      tags: [FLAPI]
+      summary: Run package (legacy alias)
+      security:
+        - FlapiAuth: []
+      parameters:
+        - name: packageId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '200':
+          description: Stub cube results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PackageRunResponse'
+        '400':
+          description: Invalid package ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '401':
+          description: Missing Authorization header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+
+  /api/flapi/package/v3/{packageId}:
+    post:
+      tags: [FLAPI]
+      summary: Run package v3 (legacy alias)
+      security:
+        - FlapiAuth: []
+      parameters:
+        - name: packageId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '200':
+          description: Stub cube results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PackageRunResponse'
+        '400':
+          description: Invalid package ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '401':
+          description: Missing Authorization header
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+
+  /api/config:
+    get:
+      tags: [Client]
+      summary: Client configuration
+      responses:
+        '200':
+          description: Mock client config
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigResponse'
+
+  /api/models:
+    get:
+      tags: [Client]
+      summary: Available mock models
+      responses:
+        '200':
+          description: Model list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ModelInfo'
+
+  /api/libs:
+    get:
+      tags: [Client]
+      summary: Available injectable libraries
+      responses:
+        '200':
+          description: Library catalog
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LibraryInfo'
+
+  /api/generate:
+    post:
+      tags: [Agent]
+      summary: Generate HTML snippet from cube data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenerateRequest'
+      responses:
+        '200':
+          description: Generated snippet stored by runId
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+
+  /api/feedback:
+    post:
+      tags: [Agent]
+      summary: Regenerate snippet with user feedback
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FeedbackRequest'
+      responses:
+        '200':
+          description: Updated snippet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateResponse'
+        '404':
+          description: Unknown runId
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+
+  /api/model/prompt:
+    post:
+      tags: [Agent]
+      summary: Mock model prompt assembly
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ModelPromptRequest'
+      responses:
+        '200':
+          description: Assembled prompt JSON
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelPromptResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+
+  /api/snippets/{runId}.html:
+    get:
+      tags: [Agent]
+      summary: Fetch stored HTML snippet by runId
+      parameters:
+        - name: runId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: HTML snippet
+          content:
+            text/html:
+              schema:
+                type: string
+        '404':
+          description: Unknown runId
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '422':
+          description: Missing runId
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+
+  /health:
+    get:
+      tags: [Utility]
+      summary: Health check
+      responses:
+        '200':
+          description: Server is healthy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+
+  /sso:
+    get:
+      tags: [Utility]
+      summary: Mock SSO login page
+      description: Serves static HTML used as VITE_AUTH_PROVIDER_URL in local dev.
+      responses:
+        '200':
+          description: Mock SSO login HTML page
+          content:
+            text/html:
+              schema:
+                type: string

--- a/mocks/flapi-mock/package.json
+++ b/mocks/flapi-mock/package.json
@@ -10,7 +10,9 @@
   },
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.21.0"
+    "express": "^4.21.0",
+    "swagger-ui-express": "^5.0.1",
+    "yaml": "^2.8.0"
   },
   "packageManager": "pnpm@10.32.1+sha512.a706938f0e89ac1456b6563eab4edf1d1faf3368d1191fc5c59790e96dc918e4456ab2e67d613de1043d2e8c81f87303e6b40d4ffeca9df15ef1ad567348f2be",
   "devDependencies": {

--- a/mocks/flapi-mock/pnpm-lock.yaml
+++ b/mocks/flapi-mock/pnpm-lock.yaml
@@ -14,12 +14,21 @@ importers:
       express:
         specifier: ^4.21.0
         version: 4.22.1
+      swagger-ui-express:
+        specifier: ^5.0.1
+        version: 5.0.1(express@4.22.1)
+      yaml:
+        specifier: ^2.8.0
+        version: 2.9.0
     devDependencies:
       nodemon:
         specifier: ^3.1.14
         version: 3.1.14
 
 packages:
+
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -379,6 +388,15 @@ packages:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
 
+  swagger-ui-dist@5.32.6:
+    resolution: {integrity: sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==}
+
+  swagger-ui-express@5.0.1:
+    resolution: {integrity: sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==}
+    engines: {node: '>= v0.10.32'}
+    peerDependencies:
+      express: '>=4.0.0 || >=5.0.0-beta'
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -410,7 +428,14 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
 snapshots:
+
+  '@scarf/scarf@1.4.0': {}
 
   accepts@1.3.8:
     dependencies:
@@ -803,6 +828,15 @@ snapshots:
     dependencies:
       has-flag: 3.0.0
 
+  swagger-ui-dist@5.32.6:
+    dependencies:
+      '@scarf/scarf': 1.4.0
+
+  swagger-ui-express@5.0.1(express@4.22.1):
+    dependencies:
+      express: 4.22.1
+      swagger-ui-dist: 5.32.6
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -823,3 +857,5 @@ snapshots:
   utils-merge@1.0.1: {}
 
   vary@1.1.2: {}
+
+  yaml@2.9.0: {}

--- a/mocks/flapi-mock/server.js
+++ b/mocks/flapi-mock/server.js
@@ -1,7 +1,10 @@
 import express from 'express';
 import cors from 'cors';
+import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import swaggerUi from 'swagger-ui-express';
+import YAML from 'yaml';
 import { errorBody } from './errorBody.js';
 import { stubDataSourceResults, stubIntelligenceResults, stubPeopleWithPhotosResults, stubPeopleHebrewResults, stubLibs, putRun, getRun, getRealtimeMetrics, stubHRResults, stubEcommerceResults, stubLogisticsResults, stubPhoneDevicesResults, stubPhoneCallsResults, stubPhoneRepairsResults, stubPhoneMarketResults } from './stubData.js';
 
@@ -23,6 +26,21 @@ app.use('/libs', express.static(libsRoot));
 // Serve static files from public directory (mock SSO page, etc.)
 const publicRoot = path.join(__dirname, 'public');
 app.use(express.static(publicRoot));
+
+const openapiPath = path.join(__dirname, 'openapi.yaml');
+const openapiSpec = YAML.parse(fs.readFileSync(openapiPath, 'utf8'));
+
+app.get('/openapi.json', (_req, res) => {
+  res.json(openapiSpec);
+});
+
+app.use(
+  '/docs',
+  swaggerUi.serve,
+  swaggerUi.setup(openapiSpec, {
+    swaggerOptions: { url: '/openapi.json' },
+  }),
+);
 
 /** Minimal stub for flapi package search autocomplete. Server-spec §2.1: filter to Type === "Package". */
 const stubSearchResultsRaw = [
@@ -505,4 +523,5 @@ app.get('/sso', (_req, res) => {
 
 app.listen(PORT, () => {
   console.log(`Mock server listening on http://localhost:${PORT}`);
+  console.log(`Swagger UI available at http://localhost:${PORT}/docs`);
 });

--- a/mocks/flapi-mock/test-mock.js
+++ b/mocks/flapi-mock/test-mock.js
@@ -5,6 +5,7 @@
  * Default baseUrl: http://localhost:6001
  */
 const baseUrl = process.argv[2] || 'http://localhost:6001';
+const flapiAuth = { Authorization: 'Bearer mock-token' };
 
 const parseBody = async (response) => {
   const text = await response.text();
@@ -16,9 +17,14 @@ const parseBody = async (response) => {
   }
 };
 
-const get = (path) => fetch(`${baseUrl}${path}`).then(async (r) => ({ status: r.status, body: parseBody(r) }));
-const post = (path, body) =>
-  fetch(`${baseUrl}${path}`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }).then(async (r) => ({
+const get = (path, headers = {}) =>
+  fetch(`${baseUrl}${path}`, { headers }).then(async (r) => ({ status: r.status, body: parseBody(r) }));
+const post = (path, body, headers = {}) =>
+  fetch(`${baseUrl}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  }).then(async (r) => ({
     status: r.status,
     body: parseBody(r),
   }));
@@ -34,18 +40,31 @@ const run = async () => {
   assert(healthBody?.ok === true, 'GET /health body.ok should be true');
   console.log('GET /health OK');
 
-  const searchEmpty = await get('/api/flapi/packages/search');
+  const openapi = await get('/openapi.json');
+  assert(openapi.status === 200, `GET /openapi.json expected 200, got ${openapi.status}`);
+  const openapiBody = await openapi.body;
+  assert(typeof openapiBody?.openapi === 'string', 'GET /openapi.json must include openapi version');
+  assert(openapiBody?.paths && typeof openapiBody.paths === 'object', 'GET /openapi.json must include paths');
+  console.log('GET /openapi.json OK');
+
+  const docs = await get('/docs');
+  assert(docs.status === 200, `GET /docs expected 200, got ${docs.status}`);
+  const docsBody = await docs.body;
+  assert(typeof docsBody === 'string' && docsBody.includes('swagger'), 'GET /docs must return Swagger UI HTML');
+  console.log('GET /docs OK');
+
+  const searchEmpty = await get('/api/flapi/packages/search', flapiAuth);
   assert(searchEmpty.status === 422, `GET search without q expected 422, got ${searchEmpty.status}`);
   console.log('GET /api/flapi/packages/search 422 when q missing OK');
 
-  const search = await get('/api/flapi/packages/search?q=Sales');
+  const search = await get('/api/flapi/packages/search?q=Sales', flapiAuth);
   assert(search.status === 200, `GET search expected 200, got ${search.status}`);
   const searchBody = await search.body;
   assert(Array.isArray(searchBody), 'search must return array');
   assert(searchBody.every((p) => p.Type === 'Package'), 'search must return only Type===Package');
   console.log('GET /api/flapi/packages/search OK');
 
-  const flapi = await post('/api/flapi/packages/my-pkg/run', { param: 'value' });
+  const flapi = await post('/api/flapi/packages/my-pkg/run', { param: 'value' }, flapiAuth);
   assert(flapi.status === 200, `POST flapi run expected 200, got ${flapi.status}`);
   const flapiBody = await flapi.body;
   assert(flapiBody?.results && typeof flapiBody.results === 'object', 'flapi body must have results');


### PR DESCRIPTION
## Summary
- Add Swagger/OpenAPI documentation to the flapi-mock service
- Add README with setup and usage instructions
- Update mock server tests

## Test plan
- [ ] Start flapi-mock and open Swagger UI
- [ ] Run mock server tests

Made with [Cursor](https://cursor.com)