### PR TITLE
Add hash-based project deep links (FlowBolt frontend)

### DIFF
--- a/frontend/e2e/happy-path.spec.ts
+++ b/frontend/e2e/happy-path.spec.ts
@@ -90,4 +90,22 @@ test.describe('Happy path', () => {
     await expect(page.getByRole('button', { name: /dashboard/i })).toBeVisible();
     await expect(page.getByRole('button', { name: /landing page/i })).toBeVisible();
   });
+
+  test('unknown project id in url redirects to home', async ({ page }) => {
+    const projectsList = page.waitForResponse(
+      (r) => r.request().method() === 'GET' && isProjectsListGet(r.url()) && r.ok(),
+      { timeout: 60_000 }
+    );
+    await page.goto('/#/project/unknown-project-id-404', {
+      waitUntil: 'domcontentloaded',
+      timeout: 60_000,
+    });
+    await projectsList;
+
+    await expect
+      .poll(() => page.evaluate(() => window.location.hash))
+      .toMatch(new RegExp(`^#/project/${MOCK_PROJECT.id}$`));
+
+    await expect(page.getByText(MOCK_PROJECT.name)).toBeAttached({ timeout: 30_000 });
+  });
 });

--- a/frontend/e2e/happy-path.spec.ts
+++ b/frontend/e2e/happy-path.spec.ts
@@ -92,6 +92,8 @@ test.describe('Happy path', () => {
   });
 
   test('unknown project id in url redirects to home', async ({ page }) => {
+    test.setTimeout(60_000);
+
     const projectsList = page.waitForResponse(
       (r) => r.request().method() === 'GET' && isProjectsListGet(r.url()) && r.ok(),
       { timeout: 60_000 }
@@ -102,10 +104,12 @@ test.describe('Happy path', () => {
     });
     await projectsList;
 
-    await expect
-      .poll(() => page.evaluate(() => window.location.hash))
-      .toMatch(new RegExp(`^#/project/${MOCK_PROJECT.id}$`));
+    await page.waitForURL(
+      (url) => url.hash === `#/project/${MOCK_PROJECT.id}`,
+      { timeout: 60_000 },
+    );
 
-    await expect(page.getByText(MOCK_PROJECT.name)).toBeAttached({ timeout: 30_000 });
+    // Collapsed sidebar shows initials, not the full project name.
+    await expect(page.getByRole('button', { name: 'ET' })).toBeVisible({ timeout: 30_000 });
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,26 +13,12 @@ import { Loader2 } from 'lucide-react';
 import { FlowBrand } from './components/ui/flow-logo';
 import * as api from './services/api';
 import { getAppName } from './utils/easterEgg';
-
-function getProjectIdFromHash(): string | null {
-  const match = window.location.hash.match(/^#\/project\/(.+)$/);
-  return match ? match[1] : null;
-}
-
-function hasProjectsCache(): boolean {
-  try {
-    const cache = localStorage.getItem('has-projects');
-    return cache === 'true';
-  } catch {
-    return false;
-  }
-}
-
-function setHasProjectsCache(hasProjects: boolean) {
-  try {
-    localStorage.setItem('has-projects', hasProjects ? 'true' : 'false');
-  } catch {}
-}
+import { clearProjectCaches, hasProjectsCache, setHasProjectsCache } from './utils/projectCache';
+import {
+  getProjectIdFromHash,
+  resolveRouteAction,
+  goToAppHome,
+} from './utils/projectRoute';
 
 // Initialize theme before React renders to prevent flicker
 function initializeTheme() {
@@ -53,7 +39,7 @@ initializeTheme();
 
 export default function App() {
   const { t } = useTranslation();
-  const { projects, currentProject, setCurrentProject, loadProjects, createProject } = useSessionStore();
+  const { projects, setCurrentProject, loadProjects, createProject } = useSessionStore();
   const loadHistory = useChatStore((s) => s.loadHistory);
   const loadFileTree = useFilesStore((s) => s.loadFileTree);
   const resetFiles = useFilesStore((s) => s.reset);
@@ -97,7 +83,9 @@ export default function App() {
   useEffect(() => {
     loadProjects()
       .then(() => {
-        const hasProjects = useSessionStore.getState().projects.length > 0;
+        const loaded = useSessionStore.getState().projects;
+        const hasProjects = loaded.length > 0;
+        if (!hasProjects) clearProjectCaches();
         setHasProjectsCache(hasProjects);
       })
       .catch((error) => {
@@ -110,38 +98,47 @@ export default function App() {
       .finally(() => setLoading(false));
   }, [loadProjects, t]);
 
-  // On load: match URL hash to a project, or auto-select first
-  useEffect(() => {
-    if (loading || projects.length === 0) {
-      if (!loading && projects.length === 0) {
-        setShowNewProject(true);
-        setHasProjectsCache(false); // Clear cache if no projects
-      }
-      return;
-    }
-    if (currentProject) return;
-
+  const syncRouteFromUrl = useCallback(() => {
     const hashProjectId = getProjectIdFromHash();
-    const match = hashProjectId
-      ? projects.find((p) => p.id === hashProjectId)
-      : null;
-    const target = match ?? projects[0];
-    selectProject(target);
-  }, [loading, projects, currentProject, selectProject]);
+    const { projects: loadedProjects, currentProject } = useSessionStore.getState();
+    const action = resolveRouteAction({
+      hashProjectId,
+      projects: loadedProjects,
+      loading,
+      currentProjectId: currentProject?.id ?? null,
+    });
 
-  // Listen for hash changes (back/forward)
+    switch (action.type) {
+      case 'redirect_home':
+        goToAppHome();
+        return;
+      case 'show_empty_state':
+        setShowNewProject(true);
+        setHasProjectsCache(false);
+        return;
+      case 'select_project':
+        setShowNewProject(false);
+        selectProject(action.project);
+        return;
+      case 'none':
+        if (!loading && loadedProjects.length > 0) {
+          setShowNewProject(false);
+        }
+        return;
+    }
+  }, [loading, selectProject]);
+
+  useEffect(() => {
+    syncRouteFromUrl();
+  }, [syncRouteFromUrl, projects]);
+
   useEffect(() => {
     function onHashChange() {
-      const hashProjectId = getProjectIdFromHash();
-      if (!hashProjectId) return;
-      const match = projects.find((p) => p.id === hashProjectId);
-      if (match && match.id !== currentProject?.id) {
-        selectProject(match);
-      }
+      syncRouteFromUrl();
     }
     window.addEventListener('hashchange', onHashChange);
     return () => window.removeEventListener('hashchange', onHashChange);
-  }, [projects, currentProject, selectProject]);
+  }, [syncRouteFromUrl]);
 
   // Auto-recover state when network comes back online
   useEffect(() => {

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -17,6 +17,7 @@ import { useChatStore } from '../../stores/chat';
 import { useSessionStore } from '../../stores/session';
 import { useFilesStore } from '../../stores/files';
 import { useIsMobile } from '../../hooks/useIsMobile';
+import { getProjectIdFromHash, isKnownProjectId } from '../../utils/projectRoute';
 
 const SIDEBAR_WIDTH = 280;
 const BOTTOM_MIN = 120;
@@ -91,10 +92,14 @@ export function AppShell() {
   const projects = useSessionStore((s) => s.projects);
   const currentProject = useSessionStore((s) => s.currentProject);
 
-  // Use cache to determine layout before history loads to prevent flicker
-  // Read project ID from URL hash immediately (don't wait for currentProject to be set)
-  const urlProjectId = window.location.hash.match(/^#\/project\/(.+)$/)?.[1];
-  const projectIdForCache = currentProject?.id || urlProjectId;
+  // Use cache to determine layout before history loads to prevent flicker.
+  // Only trust hash ids that exist in the loaded project list (ignore unknown ids).
+  const urlProjectId = getProjectIdFromHash();
+  const urlProjectIsKnown = urlProjectId
+    ? isKnownProjectId(urlProjectId, projects)
+    : false;
+  const projectIdForCache = currentProject?.id
+    ?? (urlProjectIsKnown ? urlProjectId : null);
   const cachedHasMessages = projectIdForCache ? getProjectHasMessages(projectIdForCache) : null;
 
   const isNewProject = historyLoaded

--- a/frontend/src/components/preview/Preview.tsx
+++ b/frontend/src/components/preview/Preview.tsx
@@ -6,6 +6,7 @@ import { useConsoleStore } from '../../stores/console';
 import { RefreshCw, ExternalLink, Globe, Loader2 } from 'lucide-react';
 import { Button } from '../ui/button';
 import { publishToS3 } from '../../services/api';
+import { exportPublishedPath, previewBasePath } from '../../constants/paths';
 import { PublishModal } from '../ui/PublishModal';
 
 export function Preview() {
@@ -28,7 +29,7 @@ export function Preview() {
       return;
     }
     setLoading(true);
-    const url = `/api/preview/${projectId}/proxy/`;
+    const url = previewBasePath(projectId);
     setPreviewUrl(url);
     setLoading(false);
     console.debug('[Preview] refresh — reason: project changed', { projectId, refreshKey });
@@ -104,7 +105,7 @@ export function Preview() {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => window.open(`/api/export/${projectId}/published`, '_blank')}
+              onClick={() => window.open(exportPublishedPath(projectId), '_blank')}
               title={t('preview.viewPublishedApp')}
             >
               <ExternalLink size={14} />

--- a/frontend/src/constants/paths.ts
+++ b/frontend/src/constants/paths.ts
@@ -1,0 +1,9 @@
+/** Must stay in sync with backend flow44.paths constants. */
+
+export function previewBasePath(projectId: string): string {
+  return `/api/preview/${projectId}/proxy/`;
+}
+
+export function exportPublishedPath(projectId: string): string {
+  return `/api/export/${projectId}/published/`;
+}

--- a/frontend/src/stores/session.ts
+++ b/frontend/src/stores/session.ts
@@ -3,6 +3,7 @@ import type { Project } from '../types';
 import * as api from '../services/api';
 import { closeChatSocket } from '../services/websocket';
 import { useChatStore } from './chat';
+import { clearProjectCaches } from '../utils/projectCache';
 
 interface SessionState {
   currentProject: Project | null;
@@ -58,6 +59,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     }
     await api.deleteProject(id);
     const projects = get().projects.filter((p) => p.id !== id);
+    if (projects.length === 0) clearProjectCaches();
     const current = get().currentProject;
     if (current?.id === id) {
       const next = projects[0] ?? null;

--- a/frontend/src/utils/projectCache.ts
+++ b/frontend/src/utils/projectCache.ts
@@ -1,0 +1,39 @@
+/** Keys written by the app that relate to projects (not auth/theme). */
+const PROJECT_CACHE_PREFIXES = ['project-has-messages:', 'editor-tabs:'] as const;
+const HAS_PROJECTS_KEY = 'has-projects';
+
+export function hasProjectsCache(): boolean {
+  try {
+    return localStorage.getItem(HAS_PROJECTS_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function setHasProjectsCache(hasProjects: boolean): void {
+  try {
+    localStorage.setItem(HAS_PROJECTS_KEY, hasProjects ? 'true' : 'false');
+  } catch {
+    /* ignore quota / private mode */
+  }
+}
+
+/** Remove all project-related entries from localStorage. */
+export function clearProjectCaches(): void {
+  try {
+    localStorage.removeItem(HAS_PROJECTS_KEY);
+    const keysToRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key) continue;
+      if (PROJECT_CACHE_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+        keysToRemove.push(key);
+      }
+    }
+    for (const key of keysToRemove) {
+      localStorage.removeItem(key);
+    }
+  } catch {
+    /* ignore quota / private mode */
+  }
+}

--- a/frontend/src/utils/projectRoute.test.ts
+++ b/frontend/src/utils/projectRoute.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getProjectIdFromHash,
+  isKnownProjectId,
+  resolveRouteAction,
+} from './projectRoute';
+import type { Project } from '../types';
+
+const projects: Project[] = [
+  { id: 'aaa', name: 'A', created_at: '2024-01-01T00:00:00Z' },
+  { id: 'bbb', name: 'B', created_at: '2024-01-02T00:00:00Z' },
+];
+
+describe('getProjectIdFromHash', () => {
+  it('parses project id from hash', () => {
+    expect(getProjectIdFromHash('#/project/aaa')).toBe('aaa');
+  });
+
+  it('returns null when hash is missing or malformed', () => {
+    expect(getProjectIdFromHash('')).toBeNull();
+    expect(getProjectIdFromHash('#/project/')).toBeNull();
+    expect(getProjectIdFromHash('#/other/aaa')).toBeNull();
+  });
+});
+
+describe('resolveRouteAction', () => {
+  it('redirects home for unknown project id once projects are loaded', () => {
+    expect(
+      resolveRouteAction({
+        hashProjectId: 'missing',
+        projects,
+        loading: false,
+        currentProjectId: null,
+      }),
+    ).toEqual({ type: 'redirect_home' });
+  });
+
+  it('redirects home for unknown id even while loading flag is true', () => {
+    expect(
+      resolveRouteAction({
+        hashProjectId: 'missing',
+        projects,
+        loading: true,
+        currentProjectId: null,
+      }),
+    ).toEqual({ type: 'redirect_home' });
+  });
+
+  it('auto-selects first project on bare home url', () => {
+    expect(
+      resolveRouteAction({
+        hashProjectId: null,
+        projects,
+        loading: false,
+        currentProjectId: null,
+      }),
+    ).toEqual({ type: 'select_project', project: projects[0] });
+  });
+
+  it('does not auto-select when a project is already selected', () => {
+    expect(
+      resolveRouteAction({
+        hashProjectId: null,
+        projects,
+        loading: false,
+        currentProjectId: 'bbb',
+      }),
+    ).toEqual({ type: 'none' });
+  });
+});
+
+describe('isKnownProjectId', () => {
+  it('returns true for ids in the list', () => {
+    expect(isKnownProjectId('aaa', projects)).toBe(true);
+  });
+
+  it('returns false for unknown ids', () => {
+    expect(isKnownProjectId('missing', projects)).toBe(false);
+  });
+});

--- a/frontend/src/utils/projectRoute.ts
+++ b/frontend/src/utils/projectRoute.ts
@@ -1,0 +1,59 @@
+import type { Project } from '../types';
+import { clearProjectCaches } from './projectCache';
+
+export function getProjectIdFromHash(hash = window.location.hash): string | null {
+  const match = hash.match(/^#\/project\/([^/?#]+)$/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+export function isKnownProjectId(projectId: string, projects: Project[]): boolean {
+  return projects.some((p) => p.id === projectId);
+}
+
+/** Navigate to app home (pathname only). Drops an invalid #/project/... hash. */
+export function goToAppHome(): void {
+  if (!getProjectIdFromHash()) return;
+  clearProjectCaches();
+  const home = `${window.location.pathname}${window.location.search}`;
+  window.location.replace(home);
+}
+
+export type RouteSyncInput = {
+  hashProjectId: string | null;
+  projects: Project[];
+  loading: boolean;
+  currentProjectId: string | null;
+};
+
+export type RouteSyncAction =
+  | { type: 'redirect_home' }
+  | { type: 'select_project'; project: Project }
+  | { type: 'show_empty_state' }
+  | { type: 'none' };
+
+/** Pure routing decision used by App.tsx. */
+export function resolveRouteAction(input: RouteSyncInput): RouteSyncAction {
+  const { hashProjectId, projects, loading, currentProjectId } = input;
+
+  if (hashProjectId && projects.length > 0 && !isKnownProjectId(hashProjectId, projects)) {
+    return { type: 'redirect_home' };
+  }
+
+  if (loading) return { type: 'none' };
+
+  if (projects.length === 0) {
+    if (hashProjectId) return { type: 'redirect_home' };
+    return { type: 'show_empty_state' };
+  }
+
+  if (hashProjectId) {
+    const match = projects.find((p) => p.id === hashProjectId);
+    if (match && match.id !== currentProjectId) {
+      return { type: 'select_project', project: match };
+    }
+    return { type: 'none' };
+  }
+
+  if (currentProjectId) return { type: 'none' };
+  return { type: 'select_project', project: projects[0] };
+}

--- a/frontend/src/utils/projectRoute.ts
+++ b/frontend/src/utils/projectRoute.ts
@@ -15,7 +15,9 @@ export function goToAppHome(): void {
   if (!getProjectIdFromHash()) return;
   clearProjectCaches();
   const home = `${window.location.pathname}${window.location.search}`;
-  window.location.replace(home);
+  window.history.replaceState(null, '', home);
+  // replaceState does not fire hashchange; re-run App routing for auto-select on bare home.
+  window.dispatchEvent(new HashChangeEvent('hashchange'));
 }
 
 export type RouteSyncInput = {


### PR DESCRIPTION
## Summary
FlowBolt builder `#/project/{id}` deep links — **separate from #96**.

**1 commit** · base: `main` (#99 ✅ #97 ✅ merged)

## Test plan
- [ ] Open `#/project/{id}` — correct project loads
- [ ] Refresh on hash URL
- [ ] Sidebar switch updates hash