### PR TITLE
Add preview routing and optional package support

### DIFF
--- a/backend/pnpm-project-template/src/platform/react-router-dom/README.md
+++ b/backend/pnpm-project-template/src/platform/react-router-dom/README.md
@@ -1,0 +1,9 @@
+# react-router-dom Platform Contract
+
+Generated apps may use this folder only when `react-router-dom` is selected.
+
+- Import `getRouterBasename` from `./platform/react-router-dom/routerBasename`.
+- Wrap routes in `App.tsx` with `<BrowserRouter basename={getRouterBasename()}>`.
+- Keep `BrowserRouter` out of `main.tsx`.
+- Use `Link`, `NavLink`, or `useNavigate()` for internal routes; never use `<a href="/...">`.
+- Do not edit `vite.config.ts`, `index.html`, env files, or files under `src/platform/`.

--- a/backend/pnpm-project-template/src/platform/react-router-dom/routerBasename.ts
+++ b/backend/pnpm-project-template/src/platform/react-router-dom/routerBasename.ts
@@ -1,0 +1,10 @@
+// PLATFORM SYSTEM FILE.
+// Required for preview/export/publish base-path support when react-router-dom is selected.
+// Do not remove or rewrite during normal app generation.
+
+/** Basename for react-router-dom, derived from Vite `base` via import.meta.env.BASE_URL. */
+export function getRouterBasename(): string {
+  const base = import.meta.env.BASE_URL || '/';
+  const normalized = base.replace(/\/+$/, '');
+  return normalized || '/';
+}

--- a/backend/pnpm-project-template/src/platform/regraph/README.md
+++ b/backend/pnpm-project-template/src/platform/regraph/README.md
@@ -1,0 +1,9 @@
+# regraph Platform Contract
+
+Generated apps may use this folder only when `regraph` is selected.
+
+- Import ReGraph components from `regraph`, usually `Chart`.
+- Pass `Chart` an `items` object keyed by stable ids.
+- Link items must use `id1` and `id2` values that reference existing node ids.
+- Give every ReGraph container explicit width and height.
+- Do not edit files under `src/platform/`.

--- a/backend/pnpm-project-template/src/vite-env.d.ts
+++ b/backend/pnpm-project-template/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_BASE_PATH: string;
+  readonly VITE_API_BASE: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/backend/pnpm-project-template/vite.config.ts
+++ b/backend/pnpm-project-template/vite.config.ts
@@ -3,9 +3,10 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
+  const base = env.VITE_BASE_PATH || env.VITE_BASE || '/'
   return {
     plugins: [react()],
-    base: env.VITE_BASE ?? '/api/preview/{{PROJECT_ID}}/proxy/',
+    base,
     define: {
       'import.meta.env.VITE_AUTH_PROVIDER_URL': JSON.stringify('{{AUTH_PROVIDER_URL}}'),
       'import.meta.env.VITE_AUTH_STORAGE_KEY': JSON.stringify('{{AUTH_STORAGE_KEY}}'),

--- a/backend/src/flow44/ai/agents/execute/agent.py
+++ b/backend/src/flow44/ai/agents/execute/agent.py
@@ -5,15 +5,23 @@ import uuid
 
 from langfuse import Langfuse
 from langfuse.decorators import langfuse_context, observe
+from pydantic import ValidationError
 
 from flow44.ai.agents._base import BaseAgent
 from flow44.ai.agents.execute.execution_state import ExecutionState
 from flow44.ai.agents.execute.models import Task, WorkPlan
+from flow44.ai.agents.execute.optional_packages import (
+    OptionalPackageDecision,
+    package_capabilities,
+    package_install_names,
+    selected_package_names,
+)
 from flow44.ai.agents.execute.prompts import (
     SUMMARY_PROMPT,
     render_codegen,
     render_fix_errors,
     render_merge,
+    render_package_decision,
 )
 from flow44.ai.core.flow import Flow
 from flow44.ai.core.messages import Message
@@ -178,7 +186,11 @@ class ExecuteAgent(BaseAgent):
         await state.emit_fn({"type": "phase", "phase": "fixing"})
         state.fix_attempts += 1
 
-        prompt = render_fix_errors(errors=state.all_errors, files=state.build_state.completed_files)
+        prompt = render_fix_errors(
+            errors=state.all_errors,
+            files=state.build_state.completed_files,
+            selected_packages=state.build_state.work_plan.selected_packages if state.build_state.work_plan else None,
+        )
         try:
             generated: list[tuple[str, str]] = []
             parser = ActionParser(on_file_action=lambda p, c: generated.append((p, c)))
@@ -236,11 +248,16 @@ class ExecuteAgent(BaseAgent):
 
     async def _build_technical_plan(self, state: ExecutionState) -> WorkPlan:
         """Build technical task plan from user overview."""
+        selected_packages = await self._decide_optional_packages(state)
         merge_data: dict[str, object] = {
             "user_request": state.build_state.user_content,
             "architecture": state.build_state.architecture.model_dump(),
             "ux_design": state.build_state.ux_design.model_dump(),
             "user_preferences": [d.model_dump() for d in state.build_state.user_overview.decisions],
+            "optional_package_decision": {
+                "selected_packages": selected_packages,
+                "selected_capabilities": package_capabilities(selected_packages),
+            },
         }
         if state.build_state.data_source_contexts:
             merge_data["data_source_integrations"] = [
@@ -264,7 +281,10 @@ class ExecuteAgent(BaseAgent):
 
         raw = await complete_chat(
             [Message.user(json.dumps(merge_data, indent=2))],
-            render_merge(has_data_sources=bool(state.build_state.data_source_contexts)),
+            render_merge(
+                has_data_sources=bool(state.build_state.data_source_contexts),
+                selected_packages=selected_packages,
+            ),
             model=state.model,
             metadata=state.llm_metadata_fn("build_technical_plan"),
         )
@@ -281,13 +301,39 @@ class ExecuteAgent(BaseAgent):
             for t in plan_data.get("tasks", [])
         ]
 
+        if selected_packages:
+            await state.sandbox_ref.enable_optional_packages(package_install_names(selected_packages))
+
         return WorkPlan(
             id=f"plan-{uuid.uuid4().hex[:8]}",
             summary=plan_data.get("summary", ""),
             architecture=state.build_state.architecture,
             ux_design=state.build_state.ux_design,
             tasks=tasks,
+            selected_packages=selected_packages,
         )
+
+    async def _decide_optional_packages(self, state: ExecutionState) -> list[str]:
+        decision_input = json.dumps(
+            {
+                "user_request": state.build_state.user_content,
+                "architecture": state.build_state.architecture.model_dump(),
+                "ux_design": state.build_state.ux_design.model_dump(),
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+        raw = await complete_chat(
+            [Message.user(decision_input)],
+            render_package_decision(),
+            model=state.model,
+            metadata=state.llm_metadata_fn("decide_optional_packages"),
+        )
+        try:
+            return selected_package_names(OptionalPackageDecision.model_validate(parse_json_response(raw)))
+        except ValidationError:
+            logger.warning("[execute] Invalid optional package decision; continuing without optional packages")
+            return []
 
     async def _execute_task(self, task: Task, state: ExecutionState) -> None:
         """Execute a single task with Langfuse span."""
@@ -319,6 +365,7 @@ class ExecuteAgent(BaseAgent):
                 other_completed_files={p: c for p, c in state.build_state.completed_files.items() if p not in dep_paths}
                 or None,
                 data_source_contexts=state.build_state.data_source_contexts or None,
+                selected_packages=state.build_state.work_plan.selected_packages,
             )
 
             generated: list[tuple[str, str]] = []

--- a/backend/src/flow44/ai/agents/execute/models.py
+++ b/backend/src/flow44/ai/agents/execute/models.py
@@ -29,6 +29,7 @@ class WorkPlan(BaseModel):
     architecture: ArchitectureDesign
     ux_design: UXDesign
     tasks: list[Task]
+    selected_packages: list[str] = Field(default_factory=list)
 
     def execution_layers(self) -> list[list[Task]]:
         """Return tasks grouped by dependency layers for parallel execution."""

--- a/backend/src/flow44/ai/agents/execute/optional_packages.py
+++ b/backend/src/flow44/ai/agents/execute/optional_packages.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
-from pydantic import AliasChoices, BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class OptionalPackagePrompt(StrEnum):
@@ -57,9 +57,16 @@ OPTIONAL_PACKAGES: dict[str, OptionalPackage] = {
 
 
 class SelectedOptionalPackage(BaseModel):
-    name: str = Field(validation_alias=AliasChoices("name", "package"))
+    name: str
     capability: str = ""
     reason: str = ""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_legacy_package_key(cls, data: dict[str, object]) -> dict[str, object]:
+        if "name" not in data and "package" in data:
+            return data | {"name": data["package"]}
+        return data
 
 
 class OptionalPackageDecision(BaseModel):

--- a/backend/src/flow44/ai/agents/execute/optional_packages.py
+++ b/backend/src/flow44/ai/agents/execute/optional_packages.py
@@ -1,0 +1,110 @@
+"""Whitelisted optional npm packages for generated apps."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class OptionalPackagePrompt(StrEnum):
+    CODEGEN_CONTEXT = "codegen_context"
+    CODEGEN_RULES = "codegen_rules"
+    MERGE_RULES = "merge_rules"
+    FIX_ERRORS_RULES = "fix_errors_rules"
+
+
+@dataclass(frozen=True)
+class OptionalPackage:
+    name: str
+    capability: str
+    packages: tuple[str, ...]
+    when_to_use: str
+    when_not_to_use: str
+    template_dir: str | None = None
+
+    @property
+    def prompt_dir(self) -> str:
+        return self.template_dir or self.name
+
+    def prompt_template(self, prompt: OptionalPackagePrompt) -> str:
+        return f"optional_packages/{self.prompt_dir}/{prompt.value}.jinja2"
+
+
+OPTIONAL_PACKAGES: dict[str, OptionalPackage] = {
+    "react-router-dom": OptionalPackage(
+        name="react-router-dom",
+        capability="client_routing",
+        packages=("react-router-dom",),
+        when_to_use="Use for true multi-page client-side apps with route navigation.",
+        when_not_to_use="Do not use for tabs, dashboards, landing pages, or in-page sections.",
+    ),
+    "regraph": OptionalPackage(
+        name="regraph",
+        capability="connected_data_visualization",
+        packages=("regraph",),
+        when_to_use=(
+            "Use for interactive connected-data visualizations such as networks, entity relationship graphs, "
+            "dependency maps, investigation graphs, or timelines over graph items."
+        ),
+        when_not_to_use=(
+            "Do not use for ordinary charts, static diagrams, tree views, flowcharts, org charts, tables, "
+            "or small relationship summaries that can be built with React and CSS."
+        ),
+    ),
+}
+
+
+class SelectedOptionalPackage(BaseModel):
+    package: str
+    capability: str = ""
+    reason: str = ""
+
+
+class OptionalPackageDecision(BaseModel):
+    selected_packages: list[SelectedOptionalPackage] = Field(default_factory=list)
+
+
+def optional_package_prompt_context() -> list[dict[str, str]]:
+    return [
+        {
+            "name": package.name,
+            "capability": package.capability,
+            "when_to_use": package.when_to_use,
+            "when_not_to_use": package.when_not_to_use,
+        }
+        for package in OPTIONAL_PACKAGES.values()
+    ]
+
+
+def selected_package_names(decision: OptionalPackageDecision) -> list[str]:
+    """Extract package names from model output and keep only whitelisted packages."""
+    return validate_optional_packages([item.package for item in decision.selected_packages])
+
+
+def validate_optional_packages(package_names: list[str]) -> list[str]:
+    """Return unique whitelisted package names in selection order."""
+    selected: list[str] = []
+    seen: set[str] = set()
+    for name in package_names:
+        if name not in OPTIONAL_PACKAGES or name in seen:
+            continue
+        selected.append(name)
+        seen.add(name)
+    return selected
+
+
+def package_install_names(package_names: list[str]) -> list[str]:
+    packages: list[str] = []
+    for name in validate_optional_packages(package_names):
+        packages.extend(OPTIONAL_PACKAGES[name].packages)
+    return packages
+
+
+def has_capability(package_names: list[str], capability: str) -> bool:
+    return any(OPTIONAL_PACKAGES[name].capability == capability for name in validate_optional_packages(package_names))
+
+
+def package_capabilities(package_names: list[str]) -> list[str]:
+    return [OPTIONAL_PACKAGES[name].capability for name in validate_optional_packages(package_names)]

--- a/backend/src/flow44/ai/agents/execute/optional_packages.py
+++ b/backend/src/flow44/ai/agents/execute/optional_packages.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field
 
 
 class OptionalPackagePrompt(StrEnum):
@@ -57,7 +57,7 @@ OPTIONAL_PACKAGES: dict[str, OptionalPackage] = {
 
 
 class SelectedOptionalPackage(BaseModel):
-    package: str
+    name: str = Field(validation_alias=AliasChoices("name", "package"))
     capability: str = ""
     reason: str = ""
 
@@ -80,7 +80,7 @@ def optional_package_prompt_context() -> list[dict[str, str]]:
 
 def selected_package_names(decision: OptionalPackageDecision) -> list[str]:
     """Extract package names from model output and keep only whitelisted packages."""
-    return validate_optional_packages([item.package for item in decision.selected_packages])
+    return validate_optional_packages([item.name for item in decision.selected_packages])
 
 
 def validate_optional_packages(package_names: list[str]) -> list[str]:

--- a/backend/src/flow44/ai/agents/execute/prompts.py
+++ b/backend/src/flow44/ai/agents/execute/prompts.py
@@ -88,6 +88,7 @@ def render_codegen(  # noqa: PLR0913
         dependency_files=dependency_files,
         other_completed_exports=other_exports,
         data_source_contexts=prepared_sources,
+        selected_packages=validate_optional_packages(selected_packages or []),
         package_contexts=_render_optional_package_prompts(selected_packages, OptionalPackagePrompt.CODEGEN_CONTEXT),
         package_rules=_render_optional_package_prompts(selected_packages, OptionalPackagePrompt.CODEGEN_RULES),
     )

--- a/backend/src/flow44/ai/agents/execute/prompts.py
+++ b/backend/src/flow44/ai/agents/execute/prompts.py
@@ -5,7 +5,14 @@ import re
 from pathlib import Path
 from typing import Any
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, TemplateNotFound
+
+from flow44.ai.agents.execute.optional_packages import (
+    OPTIONAL_PACKAGES,
+    OptionalPackagePrompt,
+    optional_package_prompt_context,
+    validate_optional_packages,
+)
 
 _templates_dir = Path(__file__).parent / "templates"
 _env = Environment(  # noqa: S701 — templates are LLM prompts, not HTML; autoescape would break them
@@ -17,8 +24,16 @@ def render(template_name: str, **kwargs: Any) -> str:
     return _env.get_template(template_name).render(**kwargs)
 
 
-def render_merge(*, has_data_sources: bool = False) -> str:
-    return render("merge.jinja2", has_data_sources=has_data_sources)
+def render_merge(*, has_data_sources: bool = False, selected_packages: list[str] | None = None) -> str:
+    return render(
+        "merge.jinja2",
+        has_data_sources=has_data_sources,
+        package_merge_rules=_render_optional_package_prompts(selected_packages, OptionalPackagePrompt.MERGE_RULES),
+    )
+
+
+def render_package_decision() -> str:
+    return render("package_decision.jinja2", optional_packages=optional_package_prompt_context())
 
 
 def render_summary() -> str:
@@ -35,6 +50,7 @@ def render_codegen(  # noqa: PLR0913
     dependency_files: dict[str, str] | None = None,
     other_completed_files: dict[str, str] | None = None,
     data_source_contexts: list[dict[str, Any]] | None = None,
+    selected_packages: list[str] | None = None,
 ) -> str:
     prepared_sources = None
     if data_source_contexts:
@@ -72,11 +88,31 @@ def render_codegen(  # noqa: PLR0913
         dependency_files=dependency_files,
         other_completed_exports=other_exports,
         data_source_contexts=prepared_sources,
+        package_contexts=_render_optional_package_prompts(selected_packages, OptionalPackagePrompt.CODEGEN_CONTEXT),
+        package_rules=_render_optional_package_prompts(selected_packages, OptionalPackagePrompt.CODEGEN_RULES),
     )
 
 
-def render_fix_errors(*, errors: str, files: dict[str, str]) -> str:
-    return render("fix_errors.jinja2", errors=errors, files=files)
+def render_fix_errors(*, errors: str, files: dict[str, str], selected_packages: list[str] | None = None) -> str:
+    return render(
+        "fix_errors.jinja2",
+        errors=errors,
+        files=files,
+        package_fix_rules=_render_optional_package_prompts(selected_packages, OptionalPackagePrompt.FIX_ERRORS_RULES),
+    )
+
+
+def _render_optional_package_prompts(
+    selected_packages: list[str] | None,
+    prompt: OptionalPackagePrompt,
+) -> list[str]:
+    blocks: list[str] = []
+    for package_name in validate_optional_packages(selected_packages or []):
+        try:
+            blocks.append(render(OPTIONAL_PACKAGES[package_name].prompt_template(prompt)).strip())
+        except TemplateNotFound:
+            continue
+    return blocks
 
 
 def _extract_exports(content: str) -> str:

--- a/backend/src/flow44/ai/agents/execute/templates/codegen.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/codegen.jinja2
@@ -109,13 +109,30 @@ placeholders or ellipses.
   </flowAction>
 </flowArtifact>
 ```
+{% if package_contexts %}
+
+## Optional Package Context
+
+{% for context in package_contexts %}
+{{ context }}
+{% endfor %}
+{% endif %}
 
 Rules:
 1. All file paths are relative to the project root (e.g. src/App.tsx).
 2. Use TypeScript, React 18+, and Tailwind CSS v3.
 3. Tailwind CSS is pre-configured - use utility classes extensively for styling.
 4. Write clean, production-quality code with modern, polished UI/UX.
-5. Only output the files listed above — do not create extra files. Do NOT overwrite `src/auth`, `src/api`, `src/dataSources`, `src/config.ts` or `src/main.tsx` — they are pre-configured or generated.
-6. **CRITICAL**: Only React, TypeScript, and Tailwind CSS are available. Do NOT use or import other npm packages (no axios, lodash, zustand, date-fns, clsx, etc.). All functionality must be implemented using built-in browser APIs and the pre-installed packages only.
+5. Only output the files listed above — do not create extra files. Do NOT overwrite `src/auth`, `src/api`, `src/dataSources`, `src/config.ts`, or `src/main.tsx`.
+6. Do NOT edit files under `src/platform/`.
 7. Import from already-completed files using their exact export names.
 8. Do NOT include shell actions — only file actions.
+{% if package_rules %}
+9. The selected optional npm packages are already installed. Follow these package-specific rules and do not import other optional packages:
+{% for rule_block in package_rules %}
+{{ rule_block }}
+{% endfor %}
+{% else %}
+9. **CRITICAL**: Only React, TypeScript, Tailwind CSS, and browser APIs are available. Do not import optional npm packages.
+10. Single-page app only — do not create `src/pages/` or navigation/routing.
+{% endif %}

--- a/backend/src/flow44/ai/agents/execute/templates/codegen.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/codegen.jinja2
@@ -118,21 +118,53 @@ placeholders or ellipses.
 {% endfor %}
 {% endif %}
 
-Rules:
+## General Rules
+
 1. All file paths are relative to the project root (e.g. src/App.tsx).
 2. Use TypeScript, React 18+, and Tailwind CSS v3.
 3. Tailwind CSS is pre-configured - use utility classes extensively for styling.
 4. Write clean, production-quality code with modern, polished UI/UX.
-5. Only output the files listed above — do not create extra files. Do NOT overwrite `src/auth`, `src/api`, `src/dataSources`, `src/config.ts`, or `src/main.tsx`.
-6. Do NOT edit files under `src/platform/`.
+5. Only output the files listed above — do not create extra files.
+6. Keep changes small and focused.
 7. Import from already-completed files using their exact export names.
 8. Do NOT include shell actions — only file actions.
+
+## File Safety Rules
+
+Do not touch:
+- `package.json`, lock files, `vite.config.ts`, `index.html`, or `.env*`
+- `src/main.tsx`, `src/platform/*`, generated/template guard files, CI/CD, backend/server, or deployment files
+
+Edit only when needed:
+- `src/App.tsx`, shared layouts/components, shared mock data/types, and global CSS
+- Preserve existing behavior unless the task requires changing it
+
+Free to edit:
+- Normal app components, pages/screens, local data/helpers, hooks, types, and feature-specific files
+
+## Dependency Rules
+
+Allowed imports:
+- React / React DOM
+- Browser APIs
+- Local project files
+{% for package in selected_packages %}
+- {{ package }}
+{% endfor %}
+
+Forbidden:
+- Do not import unselected packages.
+- Do not edit `package.json`.
+- Do not install dependencies.
+- Do not use extra npm packages unless they are selected.
 {% if package_rules %}
-9. The selected optional npm packages are already installed. Follow these package-specific rules and do not import other optional packages:
+
+## Selected Package Rules
+
 {% for rule_block in package_rules %}
 {{ rule_block }}
 {% endfor %}
 {% else %}
-9. **CRITICAL**: Only React, TypeScript, Tailwind CSS, and browser APIs are available. Do not import optional npm packages.
-10. Single-page app only — do not create `src/pages/` or navigation/routing.
+
+If route-based navigation is needed but no routing package is selected, use simple state-based page-like views instead of client-side routes. Do not add router setup or routing imports unless a routing package is selected.
 {% endif %}

--- a/backend/src/flow44/ai/agents/execute/templates/fix_errors.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/fix_errors.jinja2
@@ -30,6 +30,19 @@ Rules:
 2. Do NOT change functionality — only fix type errors.
 3. Output complete file contents, not patches.
 4. Do NOT include shell actions.
+
+## File Safety Rules
+
+Do not touch:
+- `package.json`, lock files, `vite.config.ts`, `index.html`, `.env*`, `src/main.tsx`, or `src/platform/*`
+- Generated/template guard files, CI/CD, backend/server, or deployment files
+
+Edit only when needed:
+- `src/App.tsx`, shared layouts/components, shared mock data/types, and global CSS
+- Preserve existing behavior unless fixing the reported error requires changing it
+
+Free to edit:
+- Normal app components, pages/screens, local data/helpers, hooks, types, and feature-specific files
 {% if package_fix_rules %}
 
 Package-specific repair rules:

--- a/backend/src/flow44/ai/agents/execute/templates/fix_errors.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/fix_errors.jinja2
@@ -30,3 +30,10 @@ Rules:
 2. Do NOT change functionality — only fix type errors.
 3. Output complete file contents, not patches.
 4. Do NOT include shell actions.
+{% if package_fix_rules %}
+
+Package-specific repair rules:
+{% for rule_block in package_fix_rules %}
+{{ rule_block }}
+{% endfor %}
+{% endif %}

--- a/backend/src/flow44/ai/agents/execute/templates/merge.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/merge.jinja2
@@ -4,6 +4,7 @@ You will receive:
 1. The original user request
 2. An architecture design (JSON)
 3. A UI/UX design (JSON)
+4. An optional package decision (JSON)
 
 Create a task list where each task produces one or more files. Tasks should be ordered so that foundational files (types, utilities, hooks) come first, then components, then the main App integration.
 
@@ -37,9 +38,17 @@ Rules:
 - Component tasks depend on their type definitions
 - The final App.tsx integration task depends on all component tasks
 - Keep the total number of tasks reasonable (3-10 for most projects)
-- Do NOT create tasks for modifying package.json - only the pre-configured packages are available (React, TypeScript, Vite, Tailwind CSS)
+- Do NOT create tasks for modifying package.json or installing dependencies
 - Do NOT include tasks for installing dependencies or running the dev server
 - Do NOT include `src/config.ts` in any task's files — it is pre-configured and must not be overwritten
+- Do NOT include `src/main.tsx`, `vite.config.ts`, `index.html`, or files under `src/platform/`
+{% if package_merge_rules %}
+
+Package-specific task planning rules:
+{% for rule_block in package_merge_rules %}
+{{ rule_block }}
+{% endfor %}
+{% endif %}
 {% if has_data_sources %}
 
 ## Data Source Integration — Pre-Generated Files

--- a/backend/src/flow44/ai/agents/execute/templates/merge.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/merge.jinja2
@@ -38,10 +38,21 @@ Rules:
 - Component tasks depend on their type definitions
 - The final App.tsx integration task depends on all component tasks
 - Keep the total number of tasks reasonable (3-10 for most projects)
-- Do NOT create tasks for modifying package.json or installing dependencies
 - Do NOT include tasks for installing dependencies or running the dev server
-- Do NOT include `src/config.ts` in any task's files — it is pre-configured and must not be overwritten
-- Do NOT include `src/main.tsx`, `vite.config.ts`, `index.html`, or files under `src/platform/`
+- Do NOT plan imports from packages that are not selected in the optional package decision or not installed in the project
+
+## File Safety Rules
+
+Do not touch:
+- `package.json`, lock files, `vite.config.ts`, `index.html`, `.env*`, `src/main.tsx`, or `src/platform/*`
+- Generated/template guard files, CI/CD, backend/server, or deployment files
+
+Edit only when needed:
+- `src/App.tsx`, shared layouts/components, shared mock data/types, and global CSS
+- Preserve existing behavior unless the task requires changing it
+
+Free to edit:
+- Normal app components, pages/screens, local data/helpers, hooks, types, and feature-specific files
 {% if package_merge_rules %}
 
 Package-specific task planning rules:

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/README.md
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/README.md
@@ -1,0 +1,41 @@
+# Optional Package Prompt Templates
+
+Optional npm packages are whitelisted in `flow44.ai.agents.execute.optional_packages`.
+Each package can own prompt fragments under this folder.
+Prompt fragments are loaded by `OptionalPackagePrompt` in `optional_packages.py`, so each filename maps to one prompt scenario.
+
+## Directory Layout
+
+Use one folder per optional package:
+
+```text
+templates/optional_packages/<package-name>/
+  codegen_context.jinja2      # Implementation context rendered before codegen Rules
+  codegen_rules.jinja2        # Implementation rules rendered inside codegen Rules
+  merge_rules.jinja2          # Planning guidance rendered only in merge prompts
+  fix_errors_rules.jinja2     # Repair guidance rendered only in fix-error prompts
+```
+
+Only create the files a package needs. Missing files are ignored.
+
+## Add A Package
+
+1. Add one entry to `OPTIONAL_PACKAGES` in `optional_packages.py`.
+2. Set `name` to the npm package key used by package decisions.
+3. Set `packages` to the npm packages that should be installed.
+4. Set `capability`, `when_to_use`, and `when_not_to_use` for the package decision prompt.
+5. Add package prompt fragments in `templates/optional_packages/<name>/` only for the prompt scenarios that need package-specific guidance.
+
+Example:
+
+```python
+"react-router-dom": OptionalPackage(
+    name="react-router-dom",
+    capability="client_routing",
+    packages=("react-router-dom",),
+    when_to_use="Use for true multi-page client-side apps with route navigation.",
+    when_not_to_use="Do not use for tabs, dashboards, landing pages, or in-page sections.",
+),
+```
+
+If the prompt folder name cannot match the npm package name, set `template_dir`.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/codegen_context.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/codegen_context.jinja2
@@ -1,8 +1,5 @@
 ## Router Contract
 
-Preview/publish run under nested URLs. Vite `base` handles assets; React Router must use the same basename:
-
-- In `App.tsx`, wrap routes with `<BrowserRouter basename={getRouterBasename()}>`.
-- Import `getRouterBasename` from `./platform/react-router-dom/routerBasename`.
-- Keep the router in `App.tsx`; do not use `HashRouter` or move routing to `main.tsx`.
-- Use `Link`, `NavLink`, or `useNavigate()` for app routes; never `<a href="/...">`.
+Preview and shared apps run below nested URLs such as `/preview/{project_id}/` and `/shared/{handle}/`.
+Vite's base path handles asset URLs, while React Router needs the matching runtime basename from
+`src/platform/react-router-dom/routerBasename.ts` so routes remain inside that nested URL.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/codegen_context.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/codegen_context.jinja2
@@ -1,0 +1,8 @@
+## Router Contract
+
+Preview/publish run under nested URLs. Vite `base` handles assets; React Router must use the same basename:
+
+- In `App.tsx`, wrap routes with `<BrowserRouter basename={getRouterBasename()}>`.
+- Import `getRouterBasename` from `./platform/react-router-dom/routerBasename`.
+- Keep the router in `App.tsx`; do not use `HashRouter` or move routing to `main.tsx`.
+- Use `Link`, `NavLink`, or `useNavigate()` for app routes; never `<a href="/...">`.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/codegen_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/codegen_rules.jinja2
@@ -1,0 +1,6 @@
+- `react-router-dom` is installed for multi-page client routing. Follow `src/platform/react-router-dom/README.md`; the backend does not define routes for you.
+- `App.tsx` must use `BrowserRouter`, `Routes`, and `Route` from `react-router-dom`, plus `getRouterBasename` from `./platform/react-router-dom/routerBasename`.
+- Wrap routes exactly with `<BrowserRouter basename={getRouterBasename()}>`; do not use `HashRouter` and do not move the router to `main.tsx`.
+- Never edit `vite.config.ts`, `index.html`, or `.env*`.
+- In-app navigation must use `<Link to="...">`, `<NavLink>`, or `useNavigate()` with app-relative paths. Never use `<a href="/...">` for app routes.
+- Lazy-load secondary pages with `lazy(() => import('./pages/...'))` inside `<Suspense>`.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/codegen_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/codegen_rules.jinja2
@@ -1,6 +1,5 @@
 - `react-router-dom` is installed for multi-page client routing. Follow `src/platform/react-router-dom/README.md`; the backend does not define routes for you.
 - `App.tsx` must use `BrowserRouter`, `Routes`, and `Route` from `react-router-dom`, plus `getRouterBasename` from `./platform/react-router-dom/routerBasename`.
 - Wrap routes exactly with `<BrowserRouter basename={getRouterBasename()}>`; do not use `HashRouter` and do not move the router to `main.tsx`.
-- Never edit `vite.config.ts`, `index.html`, or `.env*`.
 - In-app navigation must use `<Link to="...">`, `<NavLink>`, or `useNavigate()` with app-relative paths. Never use `<a href="/...">` for app routes.
 - Lazy-load secondary pages with `lazy(() => import('./pages/...'))` inside `<Suspense>`.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/fix_errors_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/fix_errors_rules.jinja2
@@ -1,5 +1,4 @@
 Routing rules:
 - `react-router-dom` is installed — fix routing code in `App.tsx` and page components only.
-- Never edit `vite.config.ts`, `index.html`, `.env*`, or files under `src/platform/`.
 - Keep `<BrowserRouter basename={getRouterBasename()}>` in `App.tsx`; do not use `HashRouter`.
 - In-app navigation must use `Link`, `NavLink`, or `useNavigate`; never `<a href="/...">` for app routes.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/fix_errors_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/fix_errors_rules.jinja2
@@ -1,0 +1,5 @@
+Routing rules:
+- `react-router-dom` is installed — fix routing code in `App.tsx` and page components only.
+- Never edit `vite.config.ts`, `index.html`, `.env*`, or files under `src/platform/`.
+- Keep `<BrowserRouter basename={getRouterBasename()}>` in `App.tsx`; do not use `HashRouter`.
+- In-app navigation must use `Link`, `NavLink`, or `useNavigate`; never `<a href="/...">` for app routes.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/merge_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/merge_rules.jinja2
@@ -1,0 +1,1 @@
+- `react-router-dom` is selected: create page tasks under `src/pages/*` and a final `src/App.tsx` task that wires the routes.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/regraph/codegen_context.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/regraph/codegen_context.jinja2
@@ -1,0 +1,9 @@
+## ReGraph Contract
+
+`regraph` is available for interactive connected-data visualization.
+
+- Import visualization components from `regraph`, usually `Chart` for network graphs and `TimeBar` only when the UI needs time-based filtering or event timelines.
+- Follow the minimal platform contract in `src/platform/regraph/README.md`.
+- `Chart` renders items from an object keyed by stable item ids. Nodes are item entries without `id1`/`id2`; links are item entries with `id1` and `id2` referencing node ids.
+- ReGraph fills its parent element, so every chart or time bar must be inside a parent with explicit, stable width and height.
+- Keep ReGraph state in React state or memoized values in the owning component; update `items`, `selection`, and options declaratively.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/regraph/codegen_context.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/regraph/codegen_context.jinja2
@@ -1,9 +1,6 @@
 ## ReGraph Contract
 
-`regraph` is available for interactive connected-data visualization.
-
-- Import visualization components from `regraph`, usually `Chart` for network graphs and `TimeBar` only when the UI needs time-based filtering or event timelines.
-- Follow the minimal platform contract in `src/platform/regraph/README.md`.
-- `Chart` renders items from an object keyed by stable item ids. Nodes are item entries without `id1`/`id2`; links are item entries with `id1` and `id2` referencing node ids.
-- ReGraph fills its parent element, so every chart or time bar must be inside a parent with explicit, stable width and height.
-- Keep ReGraph state in React state or memoized values in the owning component; update `items`, `selection`, and options declaratively.
+ReGraph provides interactive connected-data visualization. Its `Chart` data model is an object keyed
+by stable item ids: node entries have no `id1`/`id2`, while link entries reference node ids through
+`id1` and `id2`. ReGraph visualizations fill their parent container and support declarative items,
+selection, options, and optional time filtering.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/regraph/codegen_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/regraph/codegen_rules.jinja2
@@ -1,0 +1,7 @@
+- `regraph` is installed for connected-data visualization. Import only the ReGraph APIs you use, for example `import { Chart } from 'regraph';`.
+- Follow `src/platform/regraph/README.md`. Do not edit files under `src/platform/`.
+- Use ReGraph only for relationship/network data. Do not use it for regular bar/line/pie charts, static diagrams, flowcharts, or layout-only UI.
+- Build the chart `items` as a deterministic object keyed by item id. Link entries must reference existing node ids with `id1` and `id2`.
+- Give each ReGraph container explicit dimensions with Tailwind classes or CSS, such as `h-[520px] w-full`, `min-h-[420px]`, or a responsive viewport-based height. Do not render `<Chart />` in an auto-height wrapper.
+- Prefer ReGraph's built-in interactions, selection, styling, and options over custom canvas/SVG graph rendering. Keep surrounding controls in React.
+- Do not add CDN scripts, downloaded `.tgz` files, font packages, map packages, or extra graph libraries.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/regraph/fix_errors_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/regraph/fix_errors_rules.jinja2
@@ -1,0 +1,5 @@
+ReGraph rules:
+- `regraph` is installed — fix ReGraph usage in app source files only. Do not edit package manager files or add alternate graph libraries.
+- Import ReGraph APIs from `regraph`, for example `Chart` and, only if needed, `TimeBar`.
+- If the chart is blank, first verify the parent container has explicit width and height and that link `id1`/`id2` values reference existing node ids.
+- Keep `items` as an object keyed by ids, not an array. Fix generated array-based graph data by converting it into a keyed item object before passing it to `<Chart />`.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/regraph/merge_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/regraph/merge_rules.jinja2
@@ -1,0 +1,3 @@
+- `regraph` is selected: create focused tasks for graph data shaping, the ReGraph visualization component, and any surrounding controls or detail panels. Do not create dependency-install tasks.
+- Keep ReGraph rendering in a dedicated component when the app has non-trivial controls, filtering, selection, or detail panels.
+- Ensure at least one task defines stable node/link item ids and the data-to-ReGraph item mapping before the chart task consumes it.

--- a/backend/src/flow44/ai/agents/execute/templates/package_decision.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/package_decision.jinja2
@@ -1,27 +1,34 @@
 You decide which optional npm packages this generated React app needs.
 
-Available optional packages:
+## Allowed Optional Packages
+
 {% for package in optional_packages %}
-- Package: `{{ package.name }}`
-  Capability: `{{ package.capability }}`
-  Use when: {{ package.when_to_use }}
-  Do not use when: {{ package.when_not_to_use }}
+### {{ package.name }}
+
+Capability:
+- {{ package.capability }}
+
+Use when: {{ package.when_to_use }}
+Avoid when: {{ package.when_not_to_use }}
 {% endfor %}
 
-Respond with ONLY this JSON object:
+## Selection Rules
 
-{
-  "selected_packages": [
-    {
-      "package": "react-router-dom",
-      "capability": "client_routing",
-      "reason": "The app has separate Home, Product, Cart, and Checkout pages."
-    }
-  ]
-}
+Required:
+- Select zero, one, or multiple packages from the allowed list.
+- Select every allowed package that is clearly useful for the requested app.
+- Use more than one package when the app clearly needs multiple package capabilities.
+- If no package is clearly useful, return an empty list.
+- Use the package-specific guidance above.
+- If the request is in another language, infer the intent before deciding.
 
-Rules:
-- Select only packages from the list above.
-- Prefer no optional packages when built-in React and browser APIs are enough.
-- Do not invent package names.
-- If no optional package is clearly needed, return `"selected_packages": []`.
+Forbidden:
+- Do not select packages outside the allowed list.
+- Do not select a package only because it is available.
+- Do not select packages for features that are simple to build without them.
+
+Return JSON only using this shape:
+{"selected_packages":[{"name":"allowed-package-name","capability":"capability-from-allowed-list","reason":"short reason"}]}
+
+If no package is needed:
+{"selected_packages":[]}

--- a/backend/src/flow44/ai/agents/execute/templates/package_decision.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/package_decision.jinja2
@@ -1,0 +1,27 @@
+You decide which optional npm packages this generated React app needs.
+
+Available optional packages:
+{% for package in optional_packages %}
+- Package: `{{ package.name }}`
+  Capability: `{{ package.capability }}`
+  Use when: {{ package.when_to_use }}
+  Do not use when: {{ package.when_not_to_use }}
+{% endfor %}
+
+Respond with ONLY this JSON object:
+
+{
+  "selected_packages": [
+    {
+      "package": "react-router-dom",
+      "capability": "client_routing",
+      "reason": "The app has separate Home, Product, Cart, and Checkout pages."
+    }
+  ]
+}
+
+Rules:
+- Select only packages from the list above.
+- Prefer no optional packages when built-in React and browser APIs are enough.
+- Do not invent package names.
+- If no optional package is clearly needed, return `"selected_packages": []`.

--- a/backend/src/flow44/ai/agents/fix_error/prompts.py
+++ b/backend/src/flow44/ai/agents/fix_error/prompts.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import ChoiceLoader, Environment, FileSystemLoader, TemplateNotFound
+
+from flow44.ai.agents.execute.optional_packages import OPTIONAL_PACKAGES, OptionalPackagePrompt
 
 _templates_dir = Path(__file__).parent / "templates"
+_execute_templates_dir = Path(__file__).parents[1] / "execute" / "templates"
 _env = Environment(  # noqa: S701 — templates are LLM prompts, not HTML; autoescape would break them
-    loader=FileSystemLoader(str(_templates_dir)), trim_blocks=True, lstrip_blocks=True
+    loader=ChoiceLoader([FileSystemLoader(str(_templates_dir)), FileSystemLoader(str(_execute_templates_dir))]),
+    trim_blocks=True,
+    lstrip_blocks=True,
 )
 
 
@@ -16,7 +21,7 @@ def render(template_name: str, **kwargs: Any) -> str:
 
 
 def render_fix_errors(*, errors: str, files: dict[str, str]) -> str:
-    return render("fix_errors.jinja2", errors=errors, files=files)
+    return render("fix_errors.jinja2", errors=errors, files=files, package_fix_rules=_package_fix_rules(files))
 
 
 def render_fix_error_direct(
@@ -34,4 +39,18 @@ def render_fix_error_direct(
         error_line=error_line,
         error_stack=error_stack,
         files=files,
+        package_fix_rules=_package_fix_rules(files),
     )
+
+
+def _package_fix_rules(files: dict[str, str]) -> list[str]:
+    package_json = files.get("package.json", "")
+    blocks: list[str] = []
+    for name, package in OPTIONAL_PACKAGES.items():
+        if name not in package_json:
+            continue
+        try:
+            blocks.append(render(package.prompt_template(OptionalPackagePrompt.FIX_ERRORS_RULES)).strip())
+        except TemplateNotFound:
+            continue
+    return blocks

--- a/backend/src/flow44/ai/agents/fix_error/templates/fix_error_direct.jinja2
+++ b/backend/src/flow44/ai/agents/fix_error/templates/fix_error_direct.jinja2
@@ -42,4 +42,12 @@ Rules:
 3. Do NOT refactor unrelated code
 4. Output complete file contents, not patches
 5. Do NOT include shell actions
+{% if package_fix_rules %}
+
+Package-specific repair rules:
+{% for rule_block in package_fix_rules %}
+{{ rule_block }}
+{% endfor %}
+{% else %}
 6. **CRITICAL**: Only use pre-installed packages (React, TypeScript, Vite, Tailwind CSS). Do NOT import other npm packages.
+{% endif %}

--- a/backend/src/flow44/ai/agents/fix_error/templates/fix_error_direct.jinja2
+++ b/backend/src/flow44/ai/agents/fix_error/templates/fix_error_direct.jinja2
@@ -42,6 +42,19 @@ Rules:
 3. Do NOT refactor unrelated code
 4. Output complete file contents, not patches
 5. Do NOT include shell actions
+
+## File Safety Rules
+
+Do not touch:
+- `package.json`, lock files, `vite.config.ts`, `index.html`, `.env*`, `src/main.tsx`, or `src/platform/*`
+- Generated/template guard files, CI/CD, backend/server, or deployment files
+
+Edit only when needed:
+- `src/App.tsx`, shared layouts/components, shared mock data/types, and global CSS
+- Preserve existing behavior unless fixing the reported error requires changing it
+
+Free to edit:
+- Normal app components, pages/screens, local data/helpers, hooks, types, and feature-specific files
 {% if package_fix_rules %}
 
 Package-specific repair rules:

--- a/backend/src/flow44/ai/agents/fix_error/templates/fix_errors.jinja2
+++ b/backend/src/flow44/ai/agents/fix_error/templates/fix_errors.jinja2
@@ -30,6 +30,19 @@ Rules:
 2. Do NOT change functionality — only fix type errors.
 3. Output complete file contents, not patches.
 4. Do NOT include shell actions.
+
+## File Safety Rules
+
+Do not touch:
+- `package.json`, lock files, `vite.config.ts`, `index.html`, `.env*`, `src/main.tsx`, or `src/platform/*`
+- Generated/template guard files, CI/CD, backend/server, or deployment files
+
+Edit only when needed:
+- `src/App.tsx`, shared layouts/components, shared mock data/types, and global CSS
+- Preserve existing behavior unless fixing the reported error requires changing it
+
+Free to edit:
+- Normal app components, pages/screens, local data/helpers, hooks, types, and feature-specific files
 {% if package_fix_rules %}
 
 Package-specific repair rules:

--- a/backend/src/flow44/ai/agents/fix_error/templates/fix_errors.jinja2
+++ b/backend/src/flow44/ai/agents/fix_error/templates/fix_errors.jinja2
@@ -30,3 +30,10 @@ Rules:
 2. Do NOT change functionality — only fix type errors.
 3. Output complete file contents, not patches.
 4. Do NOT include shell actions.
+{% if package_fix_rules %}
+
+Package-specific repair rules:
+{% for rule_block in package_fix_rules %}
+{{ rule_block }}
+{% endfor %}
+{% endif %}

--- a/backend/src/flow44/ai/agents/plan/templates/architecture.jinja2
+++ b/backend/src/flow44/ai/agents/plan/templates/architecture.jinja2
@@ -14,7 +14,7 @@ Given the user's request, design the technical architecture. Respond with ONLY a
     "src/types/index.ts"
   ],
   "state_management": "Description of state approach (useState, useReducer, context, etc.)",
-  "key_dependencies": "ONLY use these pre-installed packages: react, react-dom, @types/react, @types/react-dom, typescript, vite, tailwindcss, autoprefixer, postcss. Do NOT suggest adding other packages.",
+  "key_dependencies": "Use the template stack by default. Mention required capabilities, but do not invent package names; optional package selection is handled separately.",
   "notes": "Any important architectural decisions or trade-offs"
 }
 
@@ -25,7 +25,9 @@ Rules:
 - Keep it simple — prefer useState/useReducer over external state libraries unless complexity warrants it
 - All file paths are relative to the project root (e.g. src/App.tsx)
 - Include only the files that need to be created or modified
-- **CRITICAL**: ONLY use the pre-installed packages (react, react-dom, @types/react, @types/react-dom, typescript, vite, tailwindcss, autoprefixer, postcss). Do NOT suggest adding other packages or dependencies. All functionality must be implemented using built-in browser APIs and these pre-configured packages only.
+- Include `src/pages/*` only when the app genuinely needs multiple client-side pages.
+- Do not include `vite.config.ts`, `index.html`, `src/main.tsx`, or files under `src/platform/`.
+- Do not invent npm packages. Optional packages may be used only when selected and installed by the package-selection step.
 {% if data_source_contexts %}
 
 The user's request includes the following data sources. Pre-built async API functions

--- a/backend/src/flow44/api/publish.py
+++ b/backend/src/flow44/api/publish.py
@@ -10,8 +10,9 @@ from sqlalchemy.exc import IntegrityError
 from flow44.api.deps import ProjectDep
 from flow44.config import settings
 from flow44.db.project import is_handle_taken, update_project_published_url
-from flow44.integrations.s3 import deploy_single_html
-from flow44.sandbox.operations import BuildError, build_single_html
+from flow44.integrations.s3 import deploy_published_dist
+from flow44.paths import shared_base_path
+from flow44.sandbox.operations import BuildError, build_dist
 
 logger = logging.getLogger(__name__)
 
@@ -72,24 +73,24 @@ async def publish_to_s3(project: ProjectDep, body: PublishRequest = PublishReque
     if slug:
         await _validate_slug(slug, project.id)
 
-    # Build a single HTML string containing the entire app with inline assets
+    handle = slug or project.id
+
+    # Keep assets and lazy-loaded route chunks available under the public app URL.
     try:
-        html_content = await build_single_html(project.id)
+        dist_dir = await build_dist(project.id, public_base=shared_base_path(handle))
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except BuildError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    # Deploy the single HTML to S3 securely without blocking the event loop
     try:
         loop = asyncio.get_running_loop()
         # TODO - REFACTOR TO AIOBOTO3: boto3 doesn't support async so we have to run in a thread pool.
-        await loop.run_in_executor(None, deploy_single_html, html_content, project.id)
+        await loop.run_in_executor(None, deploy_published_dist, dist_dir, project.id)
     except Exception as exc:
         logger.exception("S3 deployment failed for project %s", project.id)
         raise HTTPException(status_code=502, detail=f"S3 deployment failed: {exc}") from exc
 
-    handle = slug or project.id
     try:
         await update_project_published_url(project.id, handle)
     except IntegrityError as exc:

--- a/backend/src/flow44/api/publish.py
+++ b/backend/src/flow44/api/publish.py
@@ -10,7 +10,7 @@ from sqlalchemy.exc import IntegrityError
 from flow44.api.deps import ProjectDep
 from flow44.config import settings
 from flow44.db.project import is_handle_taken, update_project_published_url
-from flow44.integrations.s3 import deploy_published_dist
+from flow44.integrations.s3 import deploy_shared_dist
 from flow44.paths import shared_base_path
 from flow44.sandbox.operations import BuildError, build_dist
 
@@ -86,7 +86,7 @@ async def publish_to_s3(project: ProjectDep, body: PublishRequest = PublishReque
     try:
         loop = asyncio.get_running_loop()
         # TODO - REFACTOR TO AIOBOTO3: boto3 doesn't support async so we have to run in a thread pool.
-        await loop.run_in_executor(None, deploy_published_dist, dist_dir, project.id)
+        await loop.run_in_executor(None, deploy_shared_dist, dist_dir, project.id)
     except Exception as exc:
         logger.exception("S3 deployment failed for project %s", project.id)
         raise HTTPException(status_code=502, detail=f"S3 deployment failed: {exc}") from exc

--- a/backend/src/flow44/api/shared.py
+++ b/backend/src/flow44/api/shared.py
@@ -1,4 +1,4 @@
-"""Public serving routes: published apps by project ID or custom slug."""
+"""Public serving routes for shared apps by project ID or custom slug."""
 
 import logging
 import mimetypes
@@ -10,7 +10,7 @@ from fastapi.responses import HTMLResponse, Response
 
 from flow44.config import settings
 from flow44.db.project import get_project_by_handle
-from flow44.integrations.s3 import get_published_asset_url, get_published_url
+from flow44.integrations.s3 import get_published_url, get_shared_asset_url
 
 logger = logging.getLogger(__name__)
 
@@ -34,21 +34,21 @@ async def _fetch_first(urls: list[str], log_ctx: str) -> httpx.Response:
                 resp.raise_for_status()
                 return resp
             except Exception:
-                logger.debug("Failed published object fetch for %s from %s", log_ctx, source_url, exc_info=True)
-    raise HTTPException(status_code=502, detail="Error fetching published app from S3.")
+                logger.debug("Failed shared object fetch for %s from %s", log_ctx, source_url, exc_info=True)
+    raise HTTPException(status_code=502, detail="Error fetching shared app from S3.")
 
 
 def _is_static_asset(path: str) -> bool:
     return bool(os.path.splitext(path)[1])
 
 
-async def _serve_published_path(handle: str, path: str) -> Response:
+async def _serve_shared_path(handle: str, path: str) -> Response:
     project = await get_project_by_handle(handle)
     if not project or not project.published_at:
-        raise HTTPException(status_code=404, detail=f"No published app found for handle '{handle}'.")
+        raise HTTPException(status_code=404, detail=f"No shared app found for handle '{handle}'.")
 
     requested_path = path.lstrip("/") or "index.html"
-    urls = [get_published_asset_url(project.id, requested_path)]
+    urls = [get_shared_asset_url(project.id, requested_path)]
     if requested_path == "index.html":
         urls.append(get_published_url(project.id))
 
@@ -58,7 +58,7 @@ async def _serve_published_path(handle: str, path: str) -> Response:
         if _is_static_asset(requested_path):
             raise
         resp = await _fetch_first(
-            [get_published_asset_url(project.id, "index.html"), get_published_url(project.id)],
+            [get_shared_asset_url(project.id, "index.html"), get_published_url(project.id)],
             f"handle {handle}, SPA fallback",
         )
 
@@ -70,15 +70,15 @@ async def _serve_published_path(handle: str, path: str) -> Response:
 
 
 @router.get("/{handle}", response_class=HTMLResponse)
-async def serve_published_app(handle: str) -> HTMLResponse:
-    """Serve a published app via its custom slug or project ID handle."""
-    response = await _serve_published_path(handle, "index.html")
+async def serve_shared_app(handle: str) -> HTMLResponse:
+    """Serve a shared app via its custom slug or project ID handle."""
+    response = await _serve_shared_path(handle, "index.html")
     if not isinstance(response, HTMLResponse):
-        raise HTTPException(status_code=502, detail="Published index is not HTML.")
+        raise HTTPException(status_code=502, detail="Shared index is not HTML.")
     return response
 
 
 @router.get("/{handle}/{path:path}")
-async def serve_published_asset_or_route(handle: str, path: str) -> Response:
-    """Serve a published asset, or index.html for a client-side route."""
-    return await _serve_published_path(handle, path)
+async def serve_shared_asset_or_route(handle: str, path: str) -> Response:
+    """Serve a shared asset, or index.html for a client-side route."""
+    return await _serve_shared_path(handle, path)

--- a/backend/src/flow44/api/shared.py
+++ b/backend/src/flow44/api/shared.py
@@ -1,46 +1,84 @@
 """Public serving routes: published apps by project ID or custom slug."""
 
 import logging
+import mimetypes
+import os
 
 import httpx
 from fastapi import APIRouter, HTTPException
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, Response
 
 from flow44.config import settings
 from flow44.db.project import get_project_by_handle
-from flow44.integrations.s3 import get_published_url
+from flow44.integrations.s3 import get_published_asset_url, get_published_url
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/shared", tags=["shared"])
 
 
-def _s3_response(html: str, headers_src: httpx.Headers) -> HTMLResponse:
+def _cache_headers(headers_src: httpx.Headers) -> dict[str, str]:
     headers: dict[str, str] = {"Cache-Control": f"public, max-age={settings.S3_CACHE_TTL}, must-revalidate"}
     if "etag" in headers_src:
         headers["ETag"] = headers_src["etag"]
     if "last-modified" in headers_src:
         headers["Last-Modified"] = headers_src["last-modified"]
-    return HTMLResponse(content=html, headers=headers)
+    return headers
 
 
-async def _proxy_from_s3(source_url: str, log_ctx: str) -> HTMLResponse:
+async def _fetch_first(urls: list[str], log_ctx: str) -> httpx.Response:
     async with httpx.AsyncClient() as client:
-        try:
-            resp = await client.get(source_url, timeout=15.0)
-            resp.raise_for_status()
-            return _s3_response(resp.text, resp.headers)
-        except Exception:
-            logger.exception("Failed to fetch published app for %s from %s", log_ctx, source_url)
-            raise HTTPException(status_code=502, detail="Error fetching published app from S3.") from None
+        for source_url in urls:
+            try:
+                resp = await client.get(source_url, timeout=15.0)
+                resp.raise_for_status()
+                return resp
+            except Exception:
+                logger.debug("Failed published object fetch for %s from %s", log_ctx, source_url, exc_info=True)
+    raise HTTPException(status_code=502, detail="Error fetching published app from S3.")
+
+
+def _is_static_asset(path: str) -> bool:
+    return bool(os.path.splitext(path)[1])
+
+
+async def _serve_published_path(handle: str, path: str) -> Response:
+    project = await get_project_by_handle(handle)
+    if not project or not project.published_at:
+        raise HTTPException(status_code=404, detail=f"No published app found for handle '{handle}'.")
+
+    requested_path = path.lstrip("/") or "index.html"
+    urls = [get_published_asset_url(project.id, requested_path)]
+    if requested_path == "index.html":
+        urls.append(get_published_url(project.id))
+
+    try:
+        resp = await _fetch_first(urls, f"handle {handle}, path {requested_path}")
+    except HTTPException:
+        if _is_static_asset(requested_path):
+            raise
+        resp = await _fetch_first(
+            [get_published_asset_url(project.id, "index.html"), get_published_url(project.id)],
+            f"handle {handle}, SPA fallback",
+        )
+
+    headers = _cache_headers(resp.headers)
+    if requested_path == "index.html" or not _is_static_asset(requested_path):
+        return HTMLResponse(content=resp.text, headers=headers)
+    media_type = resp.headers.get("content-type") or mimetypes.guess_type(requested_path)[0]
+    return Response(content=resp.content, headers=headers, media_type=media_type)
 
 
 @router.get("/{handle}", response_class=HTMLResponse)
 async def serve_published_app(handle: str) -> HTMLResponse:
     """Serve a published app via its custom slug or project ID handle."""
-    project = await get_project_by_handle(handle)
-    if not project or not project.published_at:
-        raise HTTPException(status_code=404, detail=f"No published app found for handle '{handle}'.")
+    response = await _serve_published_path(handle, "index.html")
+    if not isinstance(response, HTMLResponse):
+        raise HTTPException(status_code=502, detail="Published index is not HTML.")
+    return response
 
-    source_url = get_published_url(project.id)
-    return await _proxy_from_s3(source_url, f"handle {handle}")
+
+@router.get("/{handle}/{path:path}")
+async def serve_published_asset_or_route(handle: str, path: str) -> Response:
+    """Serve a published asset, or index.html for a client-side route."""
+    return await _serve_published_path(handle, path)

--- a/backend/src/flow44/integrations/s3.py
+++ b/backend/src/flow44/integrations/s3.py
@@ -62,7 +62,8 @@ def get_published_url(project_id: str) -> str:
     return f"{settings.S3_ENDPOINT_URL}/{settings.S3_BUCKET_NAME}/{key}"
 
 
-def get_published_asset_url(project_id: str, relative_path: str) -> str:
+def get_shared_asset_url(project_id: str, relative_path: str) -> str:
+    # Legacy storage prefix kept for backward compatibility.
     key = f"published/{project_id}/{relative_path.lstrip('/')}"
     return f"{settings.S3_ENDPOINT_URL}/{settings.S3_BUCKET_NAME}/{key}"
 
@@ -81,8 +82,8 @@ def deploy_single_html(html_content: str, project_id: str) -> str:
     return get_published_url(project_id)
 
 
-def deploy_published_dist(dist_dir: str, project_id: str) -> str:
-    """Upload a Vite dist directory under published/{project_id}/."""
+def deploy_shared_dist(dist_dir: str, project_id: str) -> str:
+    """Upload a Vite dist directory for shared serving."""
     s3 = connect_to_s3()
     for root, _, files in os.walk(dist_dir):
         for filename in files:
@@ -91,10 +92,11 @@ def deploy_published_dist(dist_dir: str, project_id: str) -> str:
             with open(absolute_path, "rb") as handle:
                 s3.put_object(
                     Bucket=settings.S3_BUCKET_NAME,
+                    # Legacy storage prefix kept for backward compatibility.
                     Key=f"published/{project_id}/{relative_path}",
                     Body=handle.read(),
                     ContentType=mimetypes.guess_type(filename)[0] or "application/octet-stream",
                     ACL="public-read",
                     StorageClass=settings.S3_STORAGE_CLASS,
                 )
-    return get_published_asset_url(project_id, "index.html")
+    return get_shared_asset_url(project_id, "index.html")

--- a/backend/src/flow44/integrations/s3.py
+++ b/backend/src/flow44/integrations/s3.py
@@ -1,6 +1,8 @@
 import functools
 import json
 import logging
+import mimetypes
+import os
 from typing import Any
 
 import boto3
@@ -55,8 +57,13 @@ def _get_s3_key(project_id: str) -> str:
 
 
 def get_published_url(project_id: str) -> str:
-    """Return the internal S3 URL for a published project."""
+    """Return the legacy single-HTML URL for a published project."""
     key = _get_s3_key(project_id)
+    return f"{settings.S3_ENDPOINT_URL}/{settings.S3_BUCKET_NAME}/{key}"
+
+
+def get_published_asset_url(project_id: str, relative_path: str) -> str:
+    key = f"published/{project_id}/{relative_path.lstrip('/')}"
     return f"{settings.S3_ENDPOINT_URL}/{settings.S3_BUCKET_NAME}/{key}"
 
 
@@ -72,3 +79,22 @@ def deploy_single_html(html_content: str, project_id: str) -> str:
         StorageClass=settings.S3_STORAGE_CLASS,
     )
     return get_published_url(project_id)
+
+
+def deploy_published_dist(dist_dir: str, project_id: str) -> str:
+    """Upload a Vite dist directory under published/{project_id}/."""
+    s3 = connect_to_s3()
+    for root, _, files in os.walk(dist_dir):
+        for filename in files:
+            absolute_path = os.path.join(root, filename)
+            relative_path = os.path.relpath(absolute_path, dist_dir).replace(os.sep, "/")
+            with open(absolute_path, "rb") as handle:
+                s3.put_object(
+                    Bucket=settings.S3_BUCKET_NAME,
+                    Key=f"published/{project_id}/{relative_path}",
+                    Body=handle.read(),
+                    ContentType=mimetypes.guess_type(filename)[0] or "application/octet-stream",
+                    ACL="public-read",
+                    StorageClass=settings.S3_STORAGE_CLASS,
+                )
+    return get_published_asset_url(project_id, "index.html")

--- a/backend/src/flow44/paths.py
+++ b/backend/src/flow44/paths.py
@@ -1,0 +1,34 @@
+"""Public base paths used by generated apps."""
+
+from __future__ import annotations
+
+import re
+
+PREVIEW_API_PREFIX = "/api/preview"
+SHARED_PREFIX = "/shared"
+
+_PUBLIC_BASE_PREFIX = re.compile(r"^(?:api/preview/[^/]+/proxy|shared/[^/]+)/")
+
+
+def preview_base_path(project_id: str) -> str:
+    return f"{PREVIEW_API_PREFIX}/{project_id}/proxy/"
+
+
+def shared_base_path(handle: str) -> str:
+    return f"{SHARED_PREFIX}/{handle}/"
+
+
+def sandbox_path_env(*, public_base: str, api_base_url: str) -> dict[str, str]:
+    """Vite env vars for preview/export/publish builds."""
+    return {
+        # VITE_BASE keeps existing workspaces compatible; VITE_BASE_PATH is the
+        # clearer name used by the current template.
+        "VITE_BASE": public_base,
+        "VITE_BASE_PATH": public_base,
+        "VITE_API_BASE": api_base_url,
+    }
+
+
+def strip_public_base_prefix(href: str) -> str:
+    """Map a generated public asset URL back to a dist-relative path."""
+    return _PUBLIC_BASE_PREFIX.sub("", href.lstrip("/\\"))

--- a/backend/src/flow44/sandbox/operations.py
+++ b/backend/src/flow44/sandbox/operations.py
@@ -9,6 +9,7 @@ import re
 from langfuse.decorators import observe
 
 from flow44.config import settings
+from flow44.paths import sandbox_path_env, strip_public_base_prefix
 from flow44.sandbox.manager import sandbox_manager
 
 logger = logging.getLogger(__name__)
@@ -73,7 +74,7 @@ def _inline_js_assets(html: str, dist_dir: str) -> str:
 
 
 def _resolve_asset_path(dist_dir: str, href: str) -> str | None:
-    cleaned = href.lstrip("/\\")
+    cleaned = strip_public_base_prefix(href)
     candidate = os.path.join(dist_dir, cleaned)
     try:
         if os.path.commonpath([os.path.realpath(dist_dir), os.path.realpath(candidate)]) != os.path.realpath(dist_dir):
@@ -88,9 +89,10 @@ def _inline_favicon(html: str, dist_dir: str, workspace_dir: str) -> str:
 
     def replace_favicon(match: re.Match[str]) -> str:
         href = match.group(1)
+        cleaned_href = strip_public_base_prefix(href)
         # Try dist first, then workspace root (dev favicons live in public/)
         for base in (dist_dir, os.path.join(workspace_dir, "public"), workspace_dir):
-            path = os.path.join(base, href.lstrip("/\\"))
+            path = os.path.join(base, cleaned_href)
             if os.path.isfile(path):
                 try:
                     with open(path, "rb") as f:
@@ -114,19 +116,17 @@ def _inline_favicon(html: str, dist_dir: str, workspace_dir: str) -> str:
     )
 
 
-@observe(name="build-single-html")  # type: ignore[untyped-decorator]
-async def build_single_html(project_id: str) -> str:
-    """Build the project and return a single self-contained HTML string."""
+async def build_dist(project_id: str, *, public_base: str = "/") -> str:
+    """Build the project and return its dist directory."""
     sandbox = await sandbox_manager.get_sandbox(project_id)
 
     workspace_dir = sandbox.workspace_dir
 
-    # Write a temporary .env.production.local so vite picks up overrides
-    api_base = settings.EXPORT_API_BASE_URL
     env_file = os.path.join(workspace_dir, ".env.production.local")
     try:
+        env_vars = sandbox_path_env(public_base=public_base, api_base_url=settings.EXPORT_API_BASE_URL)
         with open(env_file, "w", encoding="utf-8") as f:  # noqa: ASYNC230
-            f.write(f"VITE_BASE=/\nVITE_API_BASE={api_base}\n")
+            f.write("\n".join(f"{key}={value}" for key, value in env_vars.items()) + "\n")
 
         build_output_lines: list[str] = []
         async for line in sandbox.exec("pnpm build"):
@@ -143,6 +143,17 @@ async def build_single_html(project_id: str) -> str:
 
     if not os.path.isfile(index_path):  # noqa: ASYNC240
         raise BuildError(f"Build failed or dist/index.html not found.\n\n{build_output}")
+
+    return dist_dir
+
+
+@observe(name="build-single-html")  # type: ignore[untyped-decorator]
+async def build_single_html(project_id: str) -> str:
+    """Build the project and return a single self-contained HTML string."""
+    dist_dir = await build_dist(project_id)
+    sandbox = await sandbox_manager.get_sandbox(project_id)
+    workspace_dir = sandbox.workspace_dir
+    index_path = os.path.join(dist_dir, "index.html")
 
     with open(index_path, encoding="utf-8", errors="replace") as f:  # noqa: ASYNC230
         html = f.read()

--- a/backend/src/flow44/sandbox/pnpm_mixin.py
+++ b/backend/src/flow44/sandbox/pnpm_mixin.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import shutil
@@ -6,6 +7,7 @@ from abc import ABC
 from pydantic import BaseModel
 
 from flow44.config import settings
+from flow44.paths import preview_base_path, sandbox_path_env
 from flow44.sandbox.base import BaseSandbox
 
 logger = logging.getLogger(__name__)
@@ -37,10 +39,27 @@ class PnpmMixin(BaseSandbox, ABC):
         shutil.copytree(template_dir, self.workspace_dir, dirs_exist_ok=True)
 
         self._stamp_vite_config(template_dir)
+        self._configure_preview_paths()
         self.configure_npmrc()
 
         async for line in self.exec("pnpm install 2>&1"):
             logger.info("[scaffold] %s", line.rstrip())
+
+    def _npm_package_installed(self, package_name: str) -> bool:
+        pkg_path = os.path.join(self.workspace_dir, "package.json")
+        if not os.path.isfile(pkg_path):
+            return False
+        with open(pkg_path, encoding="utf-8") as handle:
+            pkg = json.load(handle)
+        return package_name in pkg.get("dependencies", {})
+
+    async def enable_optional_packages(self, package_names: list[str]) -> None:
+        """Install optional packages after they have passed the backend whitelist."""
+        for package_name in package_names:
+            if self._npm_package_installed(package_name):
+                continue
+            async for line in self.exec(f"pnpm add {package_name} 2>&1"):
+                logger.info("[optional-package:%s] %s", package_name, line.rstrip())
 
     def _stamp_vite_config(self, template_dir: str) -> None:
         template_path = os.path.join(template_dir, "vite.config.ts")
@@ -114,12 +133,28 @@ class PnpmMixin(BaseSandbox, ABC):
     async def start_dev_server(self) -> None:
         await self.stop_background_process("dev-server")
 
+        self._configure_preview_paths()
         env = os.environ.copy()
+        env.update(
+            sandbox_path_env(
+                public_base=preview_base_path(self.project_id),
+                api_base_url=settings.EXPORT_API_BASE_URL,
+            )
+        )
         env["FORCE_COLOR"] = "1"
 
         cmd = f"pnpm dev --port {self.port} --strictPort --host 0.0.0.0"
         await self._spawn_background("dev-server", cmd, env)
         logger.info("Dev server started for %s on port %d", self.project_id, self.port)
+
+    def _configure_preview_paths(self) -> None:
+        env_path = os.path.join(self.workspace_dir, ".env.local")
+        env_vars = sandbox_path_env(
+            public_base=preview_base_path(self.project_id),
+            api_base_url=settings.EXPORT_API_BASE_URL,
+        )
+        with open(env_path, "w", encoding="utf-8") as handle:
+            handle.write("\n".join(f"{key}={value}" for key, value in env_vars.items()) + "\n")
 
     async def stop_dev_server(self) -> None:
         await self.stop_background_process("dev-server")

--- a/backend/tests/ai/agents/execute/test_optional_packages.py
+++ b/backend/tests/ai/agents/execute/test_optional_packages.py
@@ -1,0 +1,65 @@
+"""Tests for optional package whitelist selection."""
+
+from __future__ import annotations
+
+from flow44.ai.agents.execute.optional_packages import (
+    OptionalPackageDecision,
+    has_capability,
+    package_capabilities,
+    package_install_names,
+    selected_package_names,
+)
+
+
+def test_selected_package_names_accepts_whitelisted_dict_items() -> None:
+    decision = OptionalPackageDecision.model_validate(
+        {
+            "selected_packages": [
+                {"package": "react-router-dom", "capability": "client_routing", "reason": "multi-page app"},
+                {"package": "regraph", "capability": "connected_data_visualization", "reason": "network graph"},
+                {"package": "made-up-router", "capability": "client_routing", "reason": "not allowed"},
+            ]
+        }
+    )
+
+    assert selected_package_names(decision) == ["react-router-dom", "regraph"]
+
+
+def test_selected_package_names_dedupes_declared_package_items() -> None:
+    decision = OptionalPackageDecision.model_validate(
+        {
+            "selected_packages": [
+                {"package": "react-router-dom", "capability": "client_routing", "reason": "multi-page app"},
+                {"package": "react-router-dom", "capability": "client_routing", "reason": "duplicate"},
+            ]
+        }
+    )
+
+    assert selected_package_names(decision) == ["react-router-dom"]
+
+
+def test_optional_package_decision_defaults_missing_selection_to_empty() -> None:
+    decision = OptionalPackageDecision.model_validate({})
+
+    assert selected_package_names(decision) == []
+
+
+def test_selected_package_names_accepts_minimal_package_items() -> None:
+    decision = OptionalPackageDecision.model_validate(
+        {
+            "selected_packages": [
+                {"package": "react-router-dom"},
+            ]
+        }
+    )
+
+    assert selected_package_names(decision) == ["react-router-dom"]
+
+
+def test_package_capability_helpers() -> None:
+    selected = ["react-router-dom", "regraph"]
+
+    assert has_capability(selected, "client_routing")
+    assert has_capability(selected, "connected_data_visualization")
+    assert package_capabilities(selected) == ["client_routing", "connected_data_visualization"]
+    assert package_install_names(selected) == ["react-router-dom", "regraph"]

--- a/backend/tests/ai/agents/execute/test_optional_packages.py
+++ b/backend/tests/ai/agents/execute/test_optional_packages.py
@@ -15,22 +15,23 @@ def test_selected_package_names_accepts_whitelisted_dict_items() -> None:
     decision = OptionalPackageDecision.model_validate(
         {
             "selected_packages": [
-                {"package": "react-router-dom", "capability": "client_routing", "reason": "multi-page app"},
-                {"package": "regraph", "capability": "connected_data_visualization", "reason": "network graph"},
-                {"package": "made-up-router", "capability": "client_routing", "reason": "not allowed"},
+                {"name": "react-router-dom", "capability": "client_routing", "reason": "multi-page app"},
+                {"name": "regraph", "capability": "connected_data_visualization", "reason": "network graph"},
+                {"name": "made-up-router", "capability": "client_routing", "reason": "not allowed"},
             ]
         }
     )
 
     assert selected_package_names(decision) == ["react-router-dom", "regraph"]
+    assert decision.selected_packages[0].capability == "client_routing"
 
 
 def test_selected_package_names_dedupes_declared_package_items() -> None:
     decision = OptionalPackageDecision.model_validate(
         {
             "selected_packages": [
-                {"package": "react-router-dom", "capability": "client_routing", "reason": "multi-page app"},
-                {"package": "react-router-dom", "capability": "client_routing", "reason": "duplicate"},
+                {"name": "react-router-dom", "reason": "multi-page app"},
+                {"name": "react-router-dom", "reason": "duplicate"},
             ]
         }
     )
@@ -44,7 +45,7 @@ def test_optional_package_decision_defaults_missing_selection_to_empty() -> None
     assert selected_package_names(decision) == []
 
 
-def test_selected_package_names_accepts_minimal_package_items() -> None:
+def test_selected_package_names_accepts_legacy_package_key() -> None:
     decision = OptionalPackageDecision.model_validate(
         {
             "selected_packages": [

--- a/backend/tests/ai/test_prompts.py
+++ b/backend/tests/ai/test_prompts.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from flow44.ai.agents.execute.prompts import render_codegen, render_merge, render_summary
+from flow44.ai.agents.execute.prompts import (
+    render_codegen,
+    render_fix_errors,
+    render_merge,
+    render_package_decision,
+    render_summary,
+)
+from flow44.ai.agents.fix_error.prompts import render_fix_error_direct
 from flow44.ai.agents.followup.prompts import render_followup
 from flow44.ai.agents.plan.prompts import render_architecture, render_user_plan
 
@@ -43,6 +50,7 @@ class TestPromptRendering:
         assert "following data sources" in result
         assert "dataSourceSalesData" in result
         assert "Pre-generated file" in result
+        assert "**Parameters:**" in result
 
     def test_architecture_without_data_sources(self) -> None:
         result = render_architecture(data_source_contexts=None)
@@ -51,6 +59,7 @@ class TestPromptRendering:
     def test_merge_without_data_sources(self) -> None:
         result = render_merge(has_data_sources=False)
         assert "Pre-Generated Files" not in result
+        assert result.count("## File Safety Rules") == 1
 
     def test_merge_with_data_sources(self) -> None:
         result = render_merge(has_data_sources=True)
@@ -90,6 +99,28 @@ class TestPromptRendering:
         assert "Create Header" in result
         assert "src/Header.tsx" in result
         assert "flowArtifact" in result
+        assert result.count("## Dependency Rules") == 1
+        assert result.count("## File Safety Rules") == 1
+        assert "state-based page-like views" in result
+        assert "Single-page app only" not in result
+
+    def test_codegen_allows_only_selected_packages(self) -> None:
+        result = render_codegen(
+            task_title="Build routed graph",
+            task_description="Build routed graph",
+            task_files=["src/App.tsx"],
+            architecture={},
+            ux_design={},
+            selected_packages=["react-router-dom", "regraph", "unknown-package"],
+        )
+
+        dependency_rules = result.split("## Dependency Rules", 1)[1].split("## Selected Package Rules", 1)[0]
+        assert result.count("## Dependency Rules") == 1
+        assert result.count("## Selected Package Rules") == 1
+        assert "- react-router-dom" in dependency_rules
+        assert "- regraph" in dependency_rules
+        assert "unknown-package" not in result
+        assert "state-based page-like views" not in result
 
     def test_codegen_with_dependencies(self) -> None:
         result = render_codegen(
@@ -137,3 +168,19 @@ class TestPromptRendering:
         assert "Analytics" in result
         assert "dataSourceAnalytics" in result
         assert "pre-generated" in result.lower()
+        assert "**Parameters:**" in result
+
+    def test_package_decision_allows_multiple_packages(self) -> None:
+        result = render_package_decision()
+
+        assert "Select zero, one, or multiple packages" in result
+        assert "Use more than one package" in result
+        assert '"name":"allowed-package-name"' in result
+        assert '"capability":"capability-from-allowed-list"' in result
+
+    def test_fix_prompts_include_file_safety_rules_once(self) -> None:
+        execute_fix = render_fix_errors(errors="broken", files={"src/App.tsx": "broken"})
+        direct_fix = render_fix_error_direct(error_message="broken", files={"src/App.tsx": "broken"})
+
+        assert execute_fix.count("## File Safety Rules") == 1
+        assert direct_fix.count("## File Safety Rules") == 1

--- a/backend/tests/api/test_export.py
+++ b/backend/tests/api/test_export.py
@@ -179,3 +179,45 @@ async def test_proxy_published_app_not_found():
         response = client.get(f"/shared/{project_id}")
         assert response.status_code == 404
         assert response.json()["detail"] == f"No published app found for handle '{project_id}'."
+
+
+@pytest.mark.asyncio
+async def test_proxy_published_asset():
+    project = AsyncMock(id="published-proj", published_at="2026-04-18T21:00:00Z")
+    with patch("flow44.api.shared.get_project_by_handle", return_value=project), patch(
+        "httpx.AsyncClient.get"
+    ) as mock_get:
+        response_from_s3 = AsyncMock()
+        response_from_s3.content = b"console.log('ok')"
+        response_from_s3.headers = {"content-type": "application/javascript"}
+        response_from_s3.raise_for_status = lambda: None
+        mock_get.return_value = response_from_s3
+
+        response = client.get("/shared/my-app/assets/main.js")
+
+    assert response.status_code == 200
+    assert response.content == b"console.log('ok')"
+
+
+@pytest.mark.asyncio
+async def test_proxy_published_spa_route_falls_back_to_index():
+    project = AsyncMock(id="published-proj", published_at="2026-04-18T21:00:00Z")
+    index_response = AsyncMock()
+    index_response.text = "<html>app</html>"
+    index_response.headers = {}
+    index_response.raise_for_status = lambda: None
+
+    async def get_object(url: str, **_: object):
+        if url.endswith("/reports/daily"):
+            raise FileNotFoundError("missing route object")
+        if url.endswith("/index.html"):
+            return index_response
+        raise AssertionError(url)
+
+    with patch("flow44.api.shared.get_project_by_handle", return_value=project), patch(
+        "httpx.AsyncClient.get", side_effect=get_object
+    ):
+        response = client.get("/shared/my-app/reports/daily")
+
+    assert response.status_code == 200
+    assert response.text == "<html>app</html>"

--- a/backend/tests/api/test_export.py
+++ b/backend/tests/api/test_export.py
@@ -131,7 +131,7 @@ async def test_export_html_error():
 
 
 @pytest.mark.asyncio
-async def test_proxy_published_app_basic():
+async def test_proxy_shared_app_basic():
     project_id = "published-proj"
     mock_project = AsyncMock()
     mock_project.id = project_id
@@ -157,7 +157,7 @@ async def test_proxy_published_app_basic():
 
 
 @pytest.mark.asyncio
-async def test_proxy_published_app_fetch_error():
+async def test_proxy_shared_app_fetch_error():
     project_id = "fetch-err"
     mock_project = AsyncMock()
     mock_project.id = project_id
@@ -169,20 +169,20 @@ async def test_proxy_published_app_fetch_error():
             with patch("httpx.AsyncClient.get", side_effect=Exception("S3 Down")):
                 response = client.get(f"/shared/{project_id}")
                 assert response.status_code == 502
-                assert response.json()["detail"] == "Error fetching published app from S3."
+                assert response.json()["detail"] == "Error fetching shared app from S3."
 
 
 @pytest.mark.asyncio
-async def test_proxy_published_app_not_found():
+async def test_proxy_shared_app_not_found():
     project_id = "non-existent"
     with patch("flow44.api.shared.get_project_by_handle", return_value=None):
         response = client.get(f"/shared/{project_id}")
         assert response.status_code == 404
-        assert response.json()["detail"] == f"No published app found for handle '{project_id}'."
+        assert response.json()["detail"] == f"No shared app found for handle '{project_id}'."
 
 
 @pytest.mark.asyncio
-async def test_proxy_published_asset():
+async def test_proxy_shared_asset():
     project = AsyncMock(id="published-proj", published_at="2026-04-18T21:00:00Z")
     with patch("flow44.api.shared.get_project_by_handle", return_value=project), patch(
         "httpx.AsyncClient.get"
@@ -200,7 +200,7 @@ async def test_proxy_published_asset():
 
 
 @pytest.mark.asyncio
-async def test_proxy_published_spa_route_falls_back_to_index():
+async def test_proxy_shared_spa_route_falls_back_to_index():
     project = AsyncMock(id="published-proj", published_at="2026-04-18T21:00:00Z")
     index_response = AsyncMock()
     index_response.text = "<html>app</html>"

--- a/backend/tests/api/test_publish_slug.py
+++ b/backend/tests/api/test_publish_slug.py
@@ -69,7 +69,7 @@ class TestPublish:
     def _patch_build_and_deploy(self):
         return (
             patch("flow44.api.publish.build_dist", return_value="dist"),
-            patch("flow44.api.publish.deploy_published_dist", return_value=MOCK_S3_URL),
+            patch("flow44.api.publish.deploy_shared_dist", return_value=MOCK_S3_URL),
             patch.object(settings, "S3_BUCKET_NAME", "test-bucket"),
         )
 
@@ -216,7 +216,7 @@ class TestShareBySlug:
         with patch("flow44.api.shared.get_project_by_handle", return_value=None):
             response = client.get("/shared/nonexistent")
             assert response.status_code == 404
-            assert "No published app found" in response.json()["detail"]
+            assert "No shared app found" in response.json()["detail"]
 
     @pytest.mark.asyncio
     async def test_share_route_is_public(self):
@@ -256,4 +256,4 @@ class TestShareBySlug:
                  patch("httpx.AsyncClient.get", side_effect=Exception("S3 down")):
                 response = client.get("/shared/my-app")
                 assert response.status_code == 502
-                assert "Error fetching published app" in response.json()["detail"]
+                assert "Error fetching shared app" in response.json()["detail"]

--- a/backend/tests/api/test_publish_slug.py
+++ b/backend/tests/api/test_publish_slug.py
@@ -68,8 +68,8 @@ class TestPublish:
 
     def _patch_build_and_deploy(self):
         return (
-            patch("flow44.api.publish.build_single_html", return_value="<html>ok</html>"),
-            patch("flow44.api.publish.deploy_single_html", return_value=MOCK_S3_URL),
+            patch("flow44.api.publish.build_dist", return_value="dist"),
+            patch("flow44.api.publish.deploy_published_dist", return_value=MOCK_S3_URL),
             patch.object(settings, "S3_BUCKET_NAME", "test-bucket"),
         )
 
@@ -77,7 +77,7 @@ class TestPublish:
     async def test_publish_with_slug(self):
         p_build, p_deploy, p_bucket = self._patch_build_and_deploy()
         with (
-            p_build,
+            p_build as mock_build,
             p_deploy,
             p_bucket,
             patch("flow44.api.publish.is_handle_taken", return_value=False),
@@ -92,6 +92,7 @@ class TestPublish:
             assert data["url"] == "/shared/my-cool-app"
             assert data["handle"] == "my-cool-app"
             mock_update.assert_awaited_once_with("proj-1", "my-cool-app")
+            mock_build.assert_awaited_once_with("proj-1", public_base="/shared/my-cool-app/")
 
     @pytest.mark.asyncio
     async def test_publish_without_slug(self):

--- a/backend/tests/integrations/test_s3_integration.py
+++ b/backend/tests/integrations/test_s3_integration.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from flow44.config import settings
-from flow44.integrations.s3 import connect_to_s3, deploy_published_dist, deploy_single_html, setup_bucket
+from flow44.integrations.s3 import connect_to_s3, deploy_shared_dist, deploy_single_html, setup_bucket
 
 
 @pytest.fixture(autouse=True)
@@ -65,7 +65,7 @@ def test_deploy_single_html():
                 assert url == f"http://s3.local/my-bucket/{expected_key}"
 
 
-def test_deploy_published_dist(tmp_path):
+def test_deploy_shared_dist(tmp_path):
     dist = tmp_path / "dist"
     (dist / "assets").mkdir(parents=True)
     (dist / "index.html").write_text("<html>index</html>")
@@ -76,7 +76,7 @@ def test_deploy_published_dist(tmp_path):
         with patch.object(settings, "S3_BUCKET_NAME", "my-bucket"), patch.object(
             settings, "S3_ENDPOINT_URL", "http://s3.local"
         ):
-            url = deploy_published_dist(str(dist), "proj-456")
+            url = deploy_shared_dist(str(dist), "proj-456")
 
     assert mock_connect.return_value.put_object.call_count == 2
     assert url == "http://s3.local/my-bucket/published/proj-456/index.html"

--- a/backend/tests/integrations/test_s3_integration.py
+++ b/backend/tests/integrations/test_s3_integration.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from flow44.config import settings
-from flow44.integrations.s3 import connect_to_s3, deploy_single_html, setup_bucket
+from flow44.integrations.s3 import connect_to_s3, deploy_published_dist, deploy_single_html, setup_bucket
 
 
 @pytest.fixture(autouse=True)
@@ -63,3 +63,20 @@ def test_deploy_single_html():
                     StorageClass=settings.S3_STORAGE_CLASS,
                 )
                 assert url == f"http://s3.local/my-bucket/{expected_key}"
+
+
+def test_deploy_published_dist(tmp_path):
+    dist = tmp_path / "dist"
+    (dist / "assets").mkdir(parents=True)
+    (dist / "index.html").write_text("<html>index</html>")
+    (dist / "assets" / "main.js").write_text("console.log('ok')")
+
+    with patch("flow44.integrations.s3.connect_to_s3") as mock_connect:
+        mock_connect.return_value = MagicMock()
+        with patch.object(settings, "S3_BUCKET_NAME", "my-bucket"), patch.object(
+            settings, "S3_ENDPOINT_URL", "http://s3.local"
+        ):
+            url = deploy_published_dist(str(dist), "proj-456")
+
+    assert mock_connect.return_value.put_object.call_count == 2
+    assert url == "http://s3.local/my-bucket/published/proj-456/index.html"

--- a/backend/tests/test_paths.py
+++ b/backend/tests/test_paths.py
@@ -1,0 +1,18 @@
+from flow44.paths import preview_base_path, sandbox_path_env, shared_base_path, strip_public_base_prefix
+
+
+def test_public_base_paths() -> None:
+    assert preview_base_path("project-1") == "/api/preview/project-1/proxy/"
+    assert shared_base_path("my-app") == "/shared/my-app/"
+
+
+def test_sandbox_path_env_supports_old_and_new_vite_configs() -> None:
+    env = sandbox_path_env(public_base="/shared/my-app/", api_base_url="https://api.example")
+    assert env["VITE_BASE"] == "/shared/my-app/"
+    assert env["VITE_BASE_PATH"] == "/shared/my-app/"
+    assert env["VITE_API_BASE"] == "https://api.example"
+
+
+def test_strip_public_base_prefix() -> None:
+    assert strip_public_base_prefix("/shared/my-app/assets/main.js") == "assets/main.js"
+    assert strip_public_base_prefix("/api/preview/project-1/proxy/assets/main.js") == "assets/main.js"

--- a/backend/tests/test_router_basename.py
+++ b/backend/tests/test_router_basename.py
@@ -1,0 +1,17 @@
+"""Tests for platform routerBasename helper in the project template."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from flow44.config import settings
+
+
+def test_router_basename_uses_base_url() -> None:
+    path = Path(settings.TEMPLATE_DIR) / "src" / "platform" / "react-router-dom" / "routerBasename.ts"
+    content = path.read_text(encoding="utf-8")
+    assert "getRouterBasename" in content
+    assert "import.meta.env.BASE_URL" in content
+    assert "VITE_BASE_PATH" not in content
+    assert "querySelector('base')" not in content
+    assert "replace(/" in content and "/+$/" in content

--- a/backend/tests/test_template_platform.py
+++ b/backend/tests/test_template_platform.py
@@ -1,0 +1,91 @@
+"""Tests for template platform routing ownership and contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from flow44.config import settings
+
+
+@pytest.fixture
+def template_root() -> Path:
+    return Path(settings.TEMPLATE_DIR)
+
+
+def test_react_router_platform_readme_exists(template_root: Path) -> None:
+    routing_md = template_root / "src" / "platform" / "react-router-dom" / "README.md"
+    assert routing_md.is_file()
+    content = routing_md.read_text(encoding="utf-8")
+    assert "getRouterBasename" in content
+    assert "./platform/react-router-dom/routerBasename" in content
+    assert "Link" in content
+    assert "Do not edit" in content or "do not edit" in content.lower()
+    assert "vite.config.ts" in content
+    assert "never use `<a href=\"/...\">`" in content.lower()
+
+
+def test_vite_config_does_not_override_base_url_define(template_root: Path) -> None:
+    content = (template_root / "vite.config.ts").read_text(encoding="utf-8")
+    assert "import.meta.env.BASE_URL" not in content
+    assert "env.BASE_URL" not in content
+
+
+def test_no_flowbolt_stub(template_root: Path) -> None:
+    assert not (template_root / "flowbolt-stub").exists()
+    assert not (template_root / "platform-stub").exists()
+
+
+def test_no_flowbolt_paths_in_template(template_root: Path) -> None:
+    skip_dirs = {"node_modules", "dist", ".git"}
+    for path in template_root.rglob("*"):
+        if any(part in skip_dirs for part in path.parts):
+            continue
+        if path.is_file() and path.suffix in {".ts", ".tsx", ".md", ".json"}:
+            text = path.read_text(encoding="utf-8", errors="replace")
+            assert "flowbolt" not in text.lower(), f"flowbolt reference in {path.relative_to(template_root)}"
+
+
+def test_vite_config_uses_public_base_path(template_root: Path) -> None:
+    content = (template_root / "vite.config.ts").read_text(encoding="utf-8")
+    assert "VITE_BASE_PATH" in content
+    assert "const base = env.VITE_BASE_PATH" in content or "env.VITE_BASE_PATH" in content
+    assert "base," in content or "base:" in content
+
+
+def test_index_html_has_no_base_tag(template_root: Path) -> None:
+    content = (template_root / "index.html").read_text(encoding="utf-8")
+    assert "<base" not in content.lower()
+
+
+def test_platform_router_basename_always_present(template_root: Path) -> None:
+    path = template_root / "src" / "platform" / "react-router-dom" / "routerBasename.ts"
+    assert path.is_file()
+
+
+def test_platform_optional_package_folders_present(template_root: Path) -> None:
+    platform = template_root / "src" / "platform"
+    assert (platform / "react-router-dom").is_dir()
+    assert (platform / "regraph").is_dir()
+    assert (platform / "react-router-dom" / "README.md").is_file()
+    assert (platform / "regraph" / "README.md").is_file()
+    assert not (platform / "regraph" / "items.ts").exists()
+
+
+def test_no_platform_app_router_in_template(template_root: Path) -> None:
+    assert not (template_root / "src" / "platform" / "AppRouter.tsx").exists()
+
+
+def test_main_tsx_renders_app_directly(template_root: Path) -> None:
+    content = (template_root / "src" / "main.tsx").read_text(encoding="utf-8")
+    assert "<App />" in content or "<App/>" in content
+    assert "BrowserRouter" not in content
+    assert "react-router-dom" not in content
+
+
+def test_package_json_no_react_router_by_default(template_root: Path) -> None:
+    pkg = json.loads((template_root / "package.json").read_text(encoding="utf-8"))
+    assert "react-router-dom" not in pkg.get("dependencies", {})
+    assert "regraph" not in pkg.get("dependencies", {})


### PR DESCRIPTION
## Summary
- add shared preview and published-app base-path handling, including SPA route and asset serving
- publish full Vite dist outputs to S3 instead of only a single HTML file
- add whitelisted optional-package selection and prompt guidance for react-router-dom and regraph
- add focused coverage for routing, template behavior, publishing, S3 deployment, and optional packages

## Verification
- `cd backend && UV_CACHE_DIR=/tmp/flowbolt-uv-cache uv run --no-sync task ruff-dry`
- `cd backend && UV_CACHE_DIR=/tmp/flowbolt-uv-cache uv run --no-sync pytest --no-cov tests/api/test_export.py tests/api/test_publish_slug.py tests/integrations/test_s3_integration.py tests/ai/agents/execute/test_optional_packages.py tests/test_paths.py tests/test_router_basename.py tests/test_template_platform.py` (47 passed)
- `git diff --check`