### PR TITLE
fix: preserve agent progress cards on page refresh and WS reconnect

### DIFF
--- a/frontend/src/components/editor/EditorPanel.tsx
+++ b/frontend/src/components/editor/EditorPanel.tsx
@@ -7,7 +7,7 @@ loader.config({ monaco });
 import { Check, Loader2 } from 'lucide-react';
 import { useFilesStore } from '../../stores/files';
 import { useChatStore } from '../../stores/chat';
-import { isAgentWorking } from '../../stores/chatAgentState';
+import { isAgentAlive } from '../../stores/chatAgentState';
 import { useSessionStore } from '../../stores/session';
 import { WRITE_ROLES } from '../../types';
 import { Resizer } from '../layout/Resizer';
@@ -46,7 +46,7 @@ export function EditorPanel() {
   const projectId = useSessionStore((s) => s.projectId);
   const currentProject = useSessionStore((s) => s.currentProject);
   const buildCompleted = useChatStore((s) => s.buildCompleted);
-  const aiFlowActive = useChatStore(isAgentWorking);
+  const aiFlowActive = useChatStore(isAgentAlive);
   const noWritePermission = currentProject?.role ? !WRITE_ROLES.has(currentProject.role) : false;
   const readOnlyUntilInitialBuildComplete = !buildCompleted;
   const editorReadOnly = noWritePermission || readOnlyUntilInitialBuildComplete || aiFlowActive;

--- a/frontend/src/components/layout/GlobalProgress.tsx
+++ b/frontend/src/components/layout/GlobalProgress.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { AgentPhase, ExecutionTask } from '../../types';
 import { useChatStore } from '../../stores/chat';
-import { AGENT_PHASE, isAgentWorking } from '../../stores/chatAgentState';
+import { AGENT_PHASE, isAgentAlive } from '../../stores/chatAgentState';
 
 function getAgentProgress(
   working: boolean,
@@ -12,7 +12,7 @@ function getAgentProgress(
 
   switch (agentPhase) {
     case AGENT_PHASE.idle:
-      return 0;
+      return working ? 5 : 0;
     case AGENT_PHASE.fetching_data_sources:
       return 10;
     case AGENT_PHASE.designing:
@@ -40,7 +40,7 @@ export function GlobalProgress() {
   const tasks = useChatStore((s) => s.executionTasks);
   const [visible, setVisible] = useState(false);
 
-  const working = useChatStore(isAgentWorking);
+  const working = useChatStore(isAgentAlive);
 
   const progress = getAgentProgress(working, agentPhase, tasks);
 

--- a/frontend/src/services/websocket/reconnecting.ts
+++ b/frontend/src/services/websocket/reconnecting.ts
@@ -43,12 +43,13 @@ export function createReconnectingSocket(
 
     socket.addEventListener('close', () => {
       socket = null;
-      onClose?.();
       if (!closed) {
         setTimeout(() => {
           retryDelay = Math.min(retryDelay * 2, maxRetryDelay);
           connect();
         }, retryDelay);
+      } else {
+        onClose?.();
       }
     });
 

--- a/frontend/src/stores/__tests__/chatHandlers.test.ts
+++ b/frontend/src/stores/__tests__/chatHandlers.test.ts
@@ -424,7 +424,7 @@ describe('finalizeHistoryReplayState', () => {
     expect(isHistoryRunComplete([{ type: 'followup_step' }])).toBe(false);
   });
 
-  it('clears stale exploring state after interrupted follow-up replay', () => {
+  it('keeps replayed state for in-progress run (alive poll handles cleanup)', () => {
     const store = createTestStore();
     const handler = createSendMessageHandler(store.set, store.get, vi.fn() as unknown as () => void);
     const events = [
@@ -441,8 +441,9 @@ describe('finalizeHistoryReplayState', () => {
 
     const didReset = finalizeHistoryReplayState(store.set, store.get, events);
     expect(didReset).toBe(true);
-    expect(store.state().agentPhase).toBe('idle');
-    expect(store.state().followUpSteps).toHaveLength(0);
+    // State is preserved — alive poll will clear if agent is dead
+    expect(store.state().agentPhase).toBe('exploring');
+    expect(store.state().followUpSteps).toHaveLength(1);
   });
 
   it('keeps awaiting approval state when plan overview is pending', () => {

--- a/frontend/src/stores/agentAlivePoll.ts
+++ b/frontend/src/stores/agentAlivePoll.ts
@@ -15,7 +15,7 @@ const POLL_MS = 10000;
 export function handleChatConnectionLost(): void {
   const state = useChatStore.getState();
   if (isAgentWorking(state) && !isAwaitingPlanApproval(state)) {
-    useChatStore.setState(getTransientReset());
+    useChatStore.setState({ ...getTransientReset(), agentAlive: false });
   }
 }
 
@@ -37,7 +37,7 @@ function reconcileAlive(alive: boolean, phase: string | null): void {
 
   if (state.error) {
     if (!alive && busyUi && !awaiting) {
-      useChatStore.setState({ ...getTransientReset(), error: state.error });
+      useChatStore.setState({ ...getTransientReset(), agentAlive: false, error: state.error });
     }
     return;
   }
@@ -52,7 +52,7 @@ function reconcileAlive(alive: boolean, phase: string | null): void {
   }
 
   if (!alive && busyUi && !awaiting) {
-    useChatStore.setState(getTransientReset());
+    useChatStore.setState({ ...getTransientReset(), agentAlive: false });
   }
 }
 

--- a/frontend/src/stores/chatAgentState.ts
+++ b/frontend/src/stores/chatAgentState.ts
@@ -34,7 +34,6 @@ export const ACTIVE_AGENT_PHASES: AgentPhase[] = [
 
 export const TRANSIENT_RESET: Partial<ChatState> = {
   isStreaming: false,
-  agentAlive: false,
   agentPhase: AGENT_PHASE.idle,
   currentAssistantMessage: '',
   actions: [],

--- a/frontend/src/stores/chatHandlers.ts
+++ b/frontend/src/stores/chatHandlers.ts
@@ -86,7 +86,7 @@ function handleText(msg: { content: string }, set: SetState) {
 }
 
 function handleError(msg: { message: string }, set: SetState, cleanup: () => void) {
-  set({ ...getTransientReset(), error: msg.message });
+  set({ ...getTransientReset(), agentAlive: false, error: msg.message });
   if (!_skipMessages) {
     notifyBuildComplete(useSessionStore.getState().currentProject?.name, true);
   }
@@ -172,10 +172,11 @@ export function createFixErrorHandler(
           set((s) => ({
             messages: [...s.messages, fixMessage],
             ...getTransientReset(),
+            agentAlive: false,
             buildCompleted: true,
           }));
         } else {
-          set({ ...getTransientReset(), buildCompleted: true });
+          set({ ...getTransientReset(), agentAlive: false, buildCompleted: true });
         }
         if (!_skipMessages) {
           notifyBuildComplete(useSessionStore.getState().currentProject?.name);
@@ -487,6 +488,7 @@ function handleActionComplete(set: SetState, get: GetState, cleanup: () => void)
   set((s) => ({
     messages: _skipMessages ? s.messages : [...s.messages, ...newMessages],
     ...getTransientReset(),
+    agentAlive: false,
     planOverview: null,
     projectSummary: null,
     buildCompleted: true,

--- a/frontend/src/stores/chatHandlers.ts
+++ b/frontend/src/stores/chatHandlers.ts
@@ -28,15 +28,20 @@ export function setReplayMode(replay: boolean) {
 
 let _lastEventTs = 0;
 
-/** Clear stale in-progress UI after replaying events from an interrupted run. */
+/**
+ * After replaying history, decide whether to keep or clear in-progress UI.
+ * If the last event is non-terminal the run may still be active — keep the
+ * replayed transient state (tasks, steps, etc.) so the cards render immediately.
+ * The alive poll will clear it if the agent turns out to be dead.
+ */
 export function finalizeHistoryReplayState(
-  set: SetState,
+  _set: SetState,
   get: GetState,
   events: Array<{ type?: string }>,
 ): boolean {
   if (isHistoryRunComplete(events)) return false;
   if (isAwaitingPlanApproval(get())) return false;
-  set(getTransientReset());
+  // Keep replayed transient state — alive poll handles stale cleanup.
   return true;
 }
 
@@ -318,8 +323,6 @@ function handlePhaseChange(
   });
   if (msg.phase === AGENT_PHASE.executing) {
     requestPermissionIfNeeded();
-  } else if (msg.phase === AGENT_PHASE.awaiting_approval && !_skipMessages) {
-    notifyAgentNeedsAttention(useSessionStore.getState().currentProject?.name);
   }
 }
 


### PR DESCRIPTION
## Summary
- **Page refresh**: `finalizeHistoryReplayState` no longer clears replayed transient state — the alive poll handles cleanup if the agent is actually dead
- **WS reconnect**: `onClose` callback only fires on permanent disconnection, not transient auto-reconnects that resolve in seconds
- **Poll stability**: removed `agentAlive: false` from `TRANSIENT_RESET` so the poll doesn't die after `plan_overview` or other transient resets
- **UI consistency**: unified `EditorPanel` and `GlobalProgress` on `isAgentAlive` (poll-aware) instead of `isAgentWorking` (local-only)
- **Duplicate notification**: removed redundant `notifyAgentNeedsAttention` from phase handler (already handled by `plan_overview`)
- **Progress flicker**: progress bar shows 5% during the brief idle→first-phase gap instead of flickering to 0%

## Regression introduced by
PR #108 ("Fix stale agent activity state") — `a58b39a`

## Test plan
- [x] `npx vitest run` — all 112 tests pass
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: start agent work → refresh page mid-execution → cards should persist
- [ ] Manual: start agent work → DevTools Network offline/online → cards should not vanish
- [ ] Manual: submit a plan → accept → progress bar tracks through execution without stalling

🤖 Generated with [Claude Code](https://claude.com/claude-code)