### PR TITLE
fix: hide file action buttons in read-only mode

### DIFF
--- a/frontend/e2e/editor.spec.ts
+++ b/frontend/e2e/editor.spec.ts
@@ -15,7 +15,7 @@ async function goToEditor(page: import('@playwright/test').Page) {
 }
 
 function fileTreeContainer(page: import('@playwright/test').Page) {
-  return page.locator('div.py-1').filter({ has: page.getByRole('button', { name: 'Create file' }) }).first();
+  return page.getByTestId('file-tree-root-dropzone').first();
 }
 
 function fileTreeRowByName(page: import('@playwright/test').Page, name: string) {
@@ -374,12 +374,12 @@ test.describe('Editor read-only gating', () => {
 
       await expect(page.getByText('Editing is enabled after the first AI build completes.').first()).toBeVisible();
 
-      const createRoot = fileTreeContainer(page).getByRole('button', { name: 'Create file' }).first();
-      await expect(createRoot).toBeDisabled();
+      const createRoot = fileTreeContainer(page).getByRole('button', { name: 'Create file' });
+      await expect(createRoot).toHaveCount(0);
       const srcRow = fileTreeRowByName(page, 'src');
       await srcRow.hover();
-      await expect(srcRow.getByTitle('Rename')).toBeDisabled();
-      await expect(srcRow.getByTitle('Delete')).toBeDisabled();
+      await expect(srcRow.getByTitle('Rename')).toHaveCount(0);
+      await expect(srcRow.getByTitle('Delete')).toHaveCount(0);
 
       const getPutCount = trackFileSaveRequests(page);
       const host = page.getByTestId('monaco-editor-host');
@@ -390,7 +390,7 @@ test.describe('Editor read-only gating', () => {
 
       await sendChatEvents([{ type: 'action_complete' }], 20);
       await expect(page.getByText('Editing is enabled after the first AI build completes.')).toHaveCount(0);
-      await expect(createRoot).toBeEnabled({ timeout: 5_000 });
+      await expect(createRoot.first()).toBeVisible({ timeout: 5_000 });
 
       await host.click();
       await page.keyboard.type('UNLOCKED_PHASE');
@@ -404,13 +404,13 @@ test.describe('Editor read-only gating', () => {
       const getUploadCount = trackUploadRequests(page);
       const initialUrl = page.url();
       const initialPageCount = page.context().pages().length;
-      const rootUploadButton = fileTreeContainer(page).getByRole('button', { name: 'Upload files' }).first();
-      await expect(rootUploadButton).toBeDisabled();
+      const rootUploadButton = fileTreeContainer(page).getByRole('button', { name: 'Upload files' });
+      await expect(rootUploadButton).toHaveCount(0);
 
       const srcRow = fileTreeRowByName(page, 'src');
       await srcRow.hover();
       const folderUploadButton = srcRow.getByTitle('Upload files');
-      await expect(folderUploadButton).toBeDisabled();
+      await expect(folderUploadButton).toHaveCount(0);
 
       const dataTransfer = await page.evaluateHandle(() => {
         const dt = new DataTransfer();
@@ -437,18 +437,18 @@ test.describe('Editor read-only gating', () => {
     test('locks while AI is working and unlocks again on completion', async ({ page, sendChatEvents }) => {
       await goToEditor(page);
 
-      const createRoot = fileTreeContainer(page).getByRole('button', { name: 'Create file' }).first();
-      await expect(createRoot).toBeEnabled();
+      const createRoot = fileTreeContainer(page).getByRole('button', { name: 'Create file' });
+      await expect(createRoot.first()).toBeVisible();
 
       const chatInput = page.getByPlaceholder(/describe what you want/i);
       await expect(chatInput).toBeVisible({ timeout: 10_000 });
       await chatInput.fill('Please continue with a tiny follow-up change');
       await page.getByRole('button', { name: /send message/i }).click();
 
-      await expect(createRoot).toBeDisabled({ timeout: 5_000 });
+      await expect(createRoot).toHaveCount(0, { timeout: 5_000 });
 
       await sendChatEvents([{ type: 'action_complete' }], 20);
-      await expect(createRoot).toBeEnabled({ timeout: 5_000 });
+      await expect(createRoot.first()).toBeVisible({ timeout: 5_000 });
     });
   });
 });

--- a/frontend/src/components/editor/FileTree.tsx
+++ b/frontend/src/components/editor/FileTree.tsx
@@ -9,10 +9,10 @@ import { joinPath, parentDirectory, ROOT_DROP_PATH } from './fileTreePaths';
 
 interface FileTreeProps {
   readOnly: boolean;
-  readOnlyMessage: string;
+  readOnlyMessage?: string;
 }
 
-export function FileTree({ readOnly, readOnlyMessage }: FileTreeProps) {
+export function FileTree({ readOnly }: FileTreeProps) {
   const { t, i18n } = useTranslation();
   const isRtl = i18n.dir(i18n.resolvedLanguage) === 'rtl';
   const fileTree = useFilesStore((s) => s.fileTree);

--- a/frontend/src/components/editor/FileTree.tsx
+++ b/frontend/src/components/editor/FileTree.tsx
@@ -173,26 +173,23 @@ export function FileTree({ readOnly, readOnlyMessage }: FileTreeProps) {
           isRootDropTarget ? 'bg-primary/10 ring-1 ring-primary/30' : ''
         }`}
       >
-        <div className="mb-1 grid w-full max-w-[260px] grid-cols-2 gap-1">
-          <button
-            type="button"
-            className="rounded border border-border bg-background px-2 py-1 text-[11px] hover:bg-muted"
-            onClick={() => openCreateDialog('/')}
-            disabled={readOnly}
-          >
-            {t('editor.createFile')}
-          </button>
-          <button
-            type="button"
-            className="rounded border border-border bg-background px-2 py-1 text-[11px] hover:bg-muted"
-            onClick={() => openUploadDialog('/')}
-            disabled={readOnly}
-          >
-            {t('editor.uploadFiles')}
-          </button>
-        </div>
-        {readOnly && (
-          <span className="text-[11px] text-muted-foreground">{readOnlyMessage}</span>
+        {!readOnly && (
+          <div className="mb-1 grid w-full max-w-[260px] grid-cols-2 gap-1">
+            <button
+              type="button"
+              className="rounded border border-border bg-background px-2 py-1 text-[11px] hover:bg-muted"
+              onClick={() => openCreateDialog('/')}
+            >
+              {t('editor.createFile')}
+            </button>
+            <button
+              type="button"
+              className="rounded border border-border bg-background px-2 py-1 text-[11px] hover:bg-muted"
+              onClick={() => openUploadDialog('/')}
+            >
+              {t('editor.uploadFiles')}
+            </button>
+          </div>
         )}
         {!readOnly && dialogError && (
           <span className="text-[11px] text-destructive">{dialogError}</span>
@@ -222,27 +219,22 @@ export function FileTree({ readOnly, readOnlyMessage }: FileTreeProps) {
         onDrop={handleRootDrop}
         className={`py-1 transition-colors ${isRootDropTarget ? 'bg-primary/10 ring-1 ring-primary/30' : ''}`}
       >
-        <div className="grid grid-cols-2 gap-1 px-2 pb-1">
-          <button
-            type="button"
-            className="rounded border border-border bg-background px-2 py-1 text-[11px] hover:bg-muted"
-            onClick={() => openCreateDialog('/')}
-            disabled={readOnly}
-          >
-            {t('editor.createFile')}
-          </button>
-          <button
-            type="button"
-            className="rounded border border-border bg-background px-2 py-1 text-[11px] hover:bg-muted"
-            onClick={() => openUploadDialog('/')}
-            disabled={readOnly}
-          >
-            {t('editor.uploadFiles')}
-          </button>
-        </div>
-        {readOnly && (
-          <div className="px-2 pb-2 text-[11px] text-muted-foreground">
-            {readOnlyMessage}
+        {!readOnly && (
+          <div className="grid grid-cols-2 gap-1 px-2 pb-1">
+            <button
+              type="button"
+              className="rounded border border-border bg-background px-2 py-1 text-[11px] hover:bg-muted"
+              onClick={() => openCreateDialog('/')}
+            >
+              {t('editor.createFile')}
+            </button>
+            <button
+              type="button"
+              className="rounded border border-border bg-background px-2 py-1 text-[11px] hover:bg-muted"
+              onClick={() => openUploadDialog('/')}
+            >
+              {t('editor.uploadFiles')}
+            </button>
           </div>
         )}
         {!readOnly && dialogError && (

--- a/frontend/src/components/editor/FileTreeNode.tsx
+++ b/frontend/src/components/editor/FileTreeNode.tsx
@@ -154,34 +154,32 @@ export function FileTreeNode({
     >
       {getFileIcon(entry.name)}
       <span className="truncate flex-1 min-w-0">{entry.name}</span>
-      <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
-        <button
-          type="button"
-          className="rounded p-0.5 hover:bg-muted"
-          onClick={(e) => {
-            e.stopPropagation();
-            if (readOnly) return;
-            onRename(entry);
-          }}
-          title={t('editor.renameFile')}
-          disabled={readOnly}
-        >
-          <Pencil size={12} />
-        </button>
-        <button
-          type="button"
-          className="rounded p-0.5 hover:bg-muted text-destructive"
-          onClick={(e) => {
-            e.stopPropagation();
-            if (readOnly) return;
-            onDelete(entry);
-          }}
-          title={t('editor.deleteFile')}
-          disabled={readOnly}
-        >
-          <Trash2 size={12} />
-        </button>
-      </div>
+      {!readOnly && (
+        <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+          <button
+            type="button"
+            className="rounded p-0.5 hover:bg-muted"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRename(entry);
+            }}
+            title={t('editor.renameFile')}
+          >
+            <Pencil size={12} />
+          </button>
+          <button
+            type="button"
+            className="rounded p-0.5 hover:bg-muted text-destructive"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete(entry);
+            }}
+            title={t('editor.deleteFile')}
+          >
+            <Trash2 size={12} />
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/editor/FileTreeNode.tsx
+++ b/frontend/src/components/editor/FileTreeNode.tsx
@@ -76,60 +76,54 @@ export function FileTreeNode({
             : <Folder size={14} className="text-primary shrink-0" />
           }
           <span className="truncate flex-1 min-w-0">{entry.name}</span>
-          <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
-            <button
-              type="button"
-              className="rounded p-0.5 hover:bg-muted"
-              onClick={(e) => {
-                e.stopPropagation();
-                if (readOnly) return;
-                onCreate(createInBasePath);
-              }}
-              title={t('editor.createFile')}
-              disabled={readOnly}
-            >
-              <Plus size={12} />
-            </button>
-            <button
-              type="button"
-              className="rounded p-0.5 hover:bg-muted"
-              onClick={(e) => {
-                e.stopPropagation();
-                if (readOnly) return;
-                onUpload(createInBasePath);
-              }}
-              title={t('editor.uploadFiles')}
-              disabled={readOnly}
-            >
-              <Upload size={12} />
-            </button>
-            <button
-              type="button"
-              className="rounded p-0.5 hover:bg-muted"
-              onClick={(e) => {
-                e.stopPropagation();
-                if (readOnly) return;
-                onRename(entry);
-              }}
-              title={t('editor.renameFile')}
-              disabled={readOnly}
-            >
-              <Pencil size={12} />
-            </button>
-            <button
-              type="button"
-              className="rounded p-0.5 hover:bg-muted text-destructive"
-              onClick={(e) => {
-                e.stopPropagation();
-                if (readOnly) return;
-                onDelete(entry);
-              }}
-              title={t('editor.deleteFile')}
-              disabled={readOnly}
-            >
-              <Trash2 size={12} />
-            </button>
-          </div>
+          {!readOnly && (
+            <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+              <button
+                type="button"
+                className="rounded p-0.5 hover:bg-muted"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCreate(createInBasePath);
+                }}
+                title={t('editor.createFile')}
+              >
+                <Plus size={12} />
+              </button>
+              <button
+                type="button"
+                className="rounded p-0.5 hover:bg-muted"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onUpload(createInBasePath);
+                }}
+                title={t('editor.uploadFiles')}
+              >
+                <Upload size={12} />
+              </button>
+              <button
+                type="button"
+                className="rounded p-0.5 hover:bg-muted"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRename(entry);
+                }}
+                title={t('editor.renameFile')}
+              >
+                <Pencil size={12} />
+              </button>
+              <button
+                type="button"
+                className="rounded p-0.5 hover:bg-muted text-destructive"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete(entry);
+                }}
+                title={t('editor.deleteFile')}
+              >
+                <Trash2 size={12} />
+              </button>
+            </div>
+          )}
         </div>
         {expanded && entry.children?.map((child) => (
           <FileTreeNode


### PR DESCRIPTION
## Summary
- Hide Create file, Upload files, Rename, and Delete buttons entirely when the editor is in read-only mode (during AI work or without write permissions)
- Previously buttons were shown but disabled — now they're fully hidden for a cleaner UI
- Updated E2E tests to assert visibility instead of disabled state

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 112 tests pass
- [ ] E2E: editor buttons hidden during AI work, visible after completion
- [ ] E2E: buttons hidden for read-only users

🤖 Generated with [Claude Code](https://claude.com/claude-code)