### PR TITLE
feat: fix followup agent memory and datasource support

### DIFF
--- a/backend/src/flow44/ai/agents/_chat_agent.py
+++ b/backend/src/flow44/ai/agents/_chat_agent.py
@@ -1,0 +1,57 @@
+from typing import Any
+
+from flow44.ai.agents._base import BaseAgent
+from flow44.db.chat import ChatRole, save_message
+
+
+class ChatAgent(BaseAgent):
+    """Base for agents that participate in the chat history (followup, fix_error)."""
+
+    async def _save_response(
+        self,
+        answer: str,
+        steps: list[dict[str, Any]],
+        files_changed: list[str],
+    ) -> None:
+        content = self._build_assistant_message(answer, steps, files_changed)
+        if content.strip():
+            await save_message(self.project_id, ChatRole.assistant, content)
+
+    @staticmethod
+    def _build_assistant_message(
+        answer: str,
+        steps: list[dict[str, Any]],
+        files_changed: list[str],
+    ) -> str:
+        parts: list[str] = []
+
+        if steps:
+            for step in steps:
+                tool = step.get("tool", "?")
+                args = step.get("args", {})
+                preview = step.get("resultPreview", "")
+
+                args_str = " ".join(
+                    f"{k}={v!r}" if not isinstance(v, str) else f"{k}={v}"
+                    for k, v in args.items()
+                    if k != "content"
+                )
+                result_short = preview[:80].replace("\n", " ").strip()
+                if len(preview) > 80:
+                    result_short += "..."
+
+                line = f"[{tool}: {args_str}".rstrip()
+                if result_short:
+                    line += f" → {result_short}"
+                line += "]"
+                parts.append(line)
+
+        if files_changed:
+            parts.append(f"[Changed: {', '.join(files_changed)}]")
+
+        if answer:
+            if parts:
+                parts.append("")
+            parts.append(answer)
+
+        return "\n".join(parts)

--- a/backend/src/flow44/ai/agents/_chat_agent.py
+++ b/backend/src/flow44/ai/agents/_chat_agent.py
@@ -32,9 +32,7 @@ class ChatAgent(BaseAgent):
                 preview = step.get("resultPreview", "")
 
                 args_str = " ".join(
-                    f"{k}={v!r}" if not isinstance(v, str) else f"{k}={v}"
-                    for k, v in args.items()
-                    if k != "content"
+                    f"{k}={v!r}" if not isinstance(v, str) else f"{k}={v}" for k, v in args.items() if k != "content"
                 )
                 result_short = preview[:80].replace("\n", " ").strip()
                 if len(preview) > 80:

--- a/backend/src/flow44/ai/agents/fix_error/agent.py
+++ b/backend/src/flow44/ai/agents/fix_error/agent.py
@@ -250,7 +250,13 @@ class FixErrorAgent(ChatAgent):
     async def _step_complete(self, state: FixErrorState) -> FixErrorState:
         """Step: Complete the fix process."""
         files = [p for p, _ in state.generated_files]
-        steps = [{"tool": "fix_error", "args": {"file": state.error_file or "unknown"}, "resultPreview": f"fixed {len(files)} file(s)"}]
+        steps = [
+            {
+                "tool": "fix_error",
+                "args": {"file": state.error_file or "unknown"},
+                "resultPreview": f"fixed {len(files)} file(s)",
+            }
+        ]
         await self._save_response(state.explanation, steps, files)
 
         await state.emit_fn({"type": "action_complete"})

--- a/backend/src/flow44/ai/agents/fix_error/agent.py
+++ b/backend/src/flow44/ai/agents/fix_error/agent.py
@@ -3,7 +3,7 @@ from pathlib import PurePosixPath
 
 from langfuse.decorators import observe
 
-from flow44.ai.agents._base import BaseAgent
+from flow44.ai.agents._chat_agent import ChatAgent
 from flow44.ai.agents.fix_error.fix_error_state import FixErrorState
 from flow44.ai.agents.fix_error.prompts import render_fix_error_direct, render_fix_errors
 from flow44.ai.core.flow import Flow
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 MAX_RETRY_ATTEMPTS = 3
 
 
-class FixErrorAgent(BaseAgent):
+class FixErrorAgent(ChatAgent):
     def __init__(
         self,
         project_id: str,
@@ -143,6 +143,7 @@ class FixErrorAgent(BaseAgent):
         artifact_start = state.full_response.find("<flowArtifact")
         cut = artifact_start if artifact_start != -1 else len(state.full_response)
         explanation = state.full_response[:cut].strip()
+        state.explanation = explanation
         if explanation:
             await state.emit_fn({"type": "text", "content": explanation + "\n\n"})
 
@@ -248,6 +249,10 @@ class FixErrorAgent(BaseAgent):
 
     async def _step_complete(self, state: FixErrorState) -> FixErrorState:
         """Step: Complete the fix process."""
+        files = [p for p, _ in state.generated_files]
+        steps = [{"tool": "fix_error", "args": {"file": state.error_file or "unknown"}, "resultPreview": f"fixed {len(files)} file(s)"}]
+        await self._save_response(state.explanation, steps, files)
+
         await state.emit_fn({"type": "action_complete"})
         await state.emit_fn({"type": "phase", "phase": "idle"})
         return state

--- a/backend/src/flow44/ai/agents/fix_error/fix_error_state.py
+++ b/backend/src/flow44/ai/agents/fix_error/fix_error_state.py
@@ -25,6 +25,7 @@ class FixErrorState(BaseModel):
     discovered_files: dict[str, str] = Field(default_factory=dict)
     generated_files: list[tuple[str, str]] = Field(default_factory=list)
     full_response: str = ""
+    explanation: str = ""
     validation_errors: str = ""
     retry_count: int = 0
 

--- a/backend/src/flow44/ai/agents/followup/agent.py
+++ b/backend/src/flow44/ai/agents/followup/agent.py
@@ -267,7 +267,7 @@ class FollowUpAgent(ChatAgent):
                 if isinstance(result, BaseException):
                     logger.warning("[followup] Failed to fetch data source: %s", result)
                 else:
-                    new_contexts.append(result)  # type: ignore[arg-type]
+                    new_contexts.append(result)
 
             if new_contexts:
                 await update_project_data_sources(self.project_id, stored_contexts + new_contexts)

--- a/backend/src/flow44/ai/agents/followup/agent.py
+++ b/backend/src/flow44/ai/agents/followup/agent.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import uuid
@@ -7,13 +8,14 @@ from typing import Any
 from langfuse.decorators import langfuse_context, observe
 from pydantic import BaseModel
 
-from flow44.ai.agents._base import BaseAgent
+from flow44.ai.agents._chat_agent import ChatAgent
 from flow44.ai.agents.followup.prompts import render_followup
 from flow44.ai.core.messages import Message
 from flow44.ai.core.react_flow import ReActFlow
 from flow44.ai.core.tools import ToolExecutor, tool
 from flow44.db.chat import get_messages
-from flow44.db.project import get_project
+from flow44.db.project import get_project, get_project_data_sources, update_project_data_sources
+from flow44.logic import data_source as ds_logic
 from flow44.sandbox.main import PnpmSandbox
 
 logger = logging.getLogger(__name__)
@@ -28,15 +30,19 @@ class FileDiff:
     diff: str
 
 
-class FollowUpAgent(BaseAgent):
+class FollowUpAgent(ChatAgent):
     def __init__(
         self,
         project_id: str,
         sandbox: PnpmSandbox,
         model: str | None = None,
         trace_id: str | None = None,
+        data_source_authorization: str | None = None,
+        data_source_ids: list[str] | None = None,
     ) -> None:
         super().__init__(project_id, sandbox, model=model, trace_id=trace_id)
+        self._data_source_authorization = data_source_authorization
+        self._data_source_ids = data_source_ids or []
         self._steps: list[dict[str, Any]] = []
         self._diffs: list[FileDiff] = []
         self._files_changed: list[str] = []
@@ -179,7 +185,6 @@ class FollowUpAgent(BaseAgent):
         await self.emit({"type": "phase", "phase": "exploring"})
         context = await self._build_context()
 
-        # TODO: fix, after change to messages in db, we dont get internal chat history anymore.
         history = await get_messages(self.project_id)
         messages = [
             Message(role=m.role, content=m.content)  # type: ignore[arg-type]
@@ -190,6 +195,7 @@ class FollowUpAgent(BaseAgent):
         system_prompt = render_followup(
             project_summary=context["summary"],
             file_tree=context["file_tree"],
+            data_source_contexts=context.get("data_source_contexts") or None,
         )
 
         react_flow: ReActFlow[BaseModel] = ReActFlow(name="followup", max_iterations=MAX_ITERATIONS)
@@ -205,6 +211,8 @@ class FollowUpAgent(BaseAgent):
         if answer:
             await self.emit({"type": "text", "content": answer})
 
+        await self._save_response(answer or "", self._steps, self._files_changed)
+
         if self._diffs:
             await self.emit(
                 {
@@ -217,8 +225,7 @@ class FollowUpAgent(BaseAgent):
         await self.emit({"type": "phase", "phase": "complete"})
         await self.emit({"type": "action_complete"})
 
-    # TODO: We will want to have a smarted memory system in the future
-    async def _build_context(self) -> dict[str, str]:
+    async def _build_context(self) -> dict[str, Any]:
         project = await get_project(self.project_id)
         summary = ""
         if project and project.summary:
@@ -238,7 +245,34 @@ class FollowUpAgent(BaseAgent):
         except Exception:
             file_tree = "(unable to list files)"
 
-        return {"summary": summary, "file_tree": file_tree}
+        data_source_contexts = await self._load_data_source_contexts()
+
+        return {"summary": summary, "file_tree": file_tree, "data_source_contexts": data_source_contexts}
+
+    async def _load_data_source_contexts(self) -> list[dict[str, Any]]:
+        """Load datasource contexts from DB, fetching any new ones not yet stored."""
+        stored_contexts = await get_project_data_sources(self.project_id)
+        stored_ids = {str(ctx.get("data_source_id")) for ctx in stored_contexts}
+
+        new_ids = [dsid for dsid in self._data_source_ids if dsid not in stored_ids]
+
+        new_contexts: list[dict[str, Any]] = []
+        if new_ids:
+            tasks = [
+                ds_logic.build_data_source_context(dsid, authorization=self._data_source_authorization)
+                for dsid in new_ids
+            ]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for result in results:
+                if isinstance(result, BaseException):
+                    logger.warning("[followup] Failed to fetch data source: %s", result)
+                else:
+                    new_contexts.append(result)  # type: ignore[arg-type]
+
+            if new_contexts:
+                await update_project_data_sources(self.project_id, stored_contexts + new_contexts)
+
+        return stored_contexts + new_contexts
 
     async def _emit_react_step(self, event: dict[str, Any]) -> None:
         """Emit ReAct step events and track state for followup agent."""

--- a/backend/src/flow44/ai/agents/followup/agent.py
+++ b/backend/src/flow44/ai/agents/followup/agent.py
@@ -183,11 +183,12 @@ class FollowUpAgent(ChatAgent):
         # (also, we need to standardize session id and project id usage across the codebase).
 
         await self.emit({"type": "phase", "phase": "exploring"})
-        context = await self._build_context()
-
-        history = await get_messages(self.project_id)
+        context, history = await asyncio.gather(
+            self._build_context(),
+            get_messages(self.project_id),
+        )
         messages = [
-            Message(role=m.role, content=m.content)  # type: ignore[arg-type]
+            Message(role=m.role, content=m.content)
             for m in history
             if m.role == "user" or (m.role == "assistant" and m.content.strip())
         ]

--- a/backend/src/flow44/ai/agents/followup/prompts.py
+++ b/backend/src/flow44/ai/agents/followup/prompts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -10,10 +11,33 @@ _env = Environment(  # noqa: S701 — templates are LLM prompts, not HTML; autoe
     loader=FileSystemLoader(str(_templates_dir)), trim_blocks=True, lstrip_blocks=True
 )
 
+_SAMPLE_DATA_MAX_CHARS = 800
+
 
 def render(template_name: str, **kwargs: Any) -> str:
     return _env.get_template(template_name).render(**kwargs)
 
 
-def render_followup(*, project_summary: str, file_tree: str) -> str:
-    return render("followup.jinja2", project_summary=project_summary, file_tree=file_tree)
+def render_followup(
+    *,
+    project_summary: str,
+    file_tree: str,
+    data_source_contexts: list[dict[str, Any]] | None = None,
+) -> str:
+    prepared_ds: list[dict[str, Any]] | None = None
+    if data_source_contexts:
+        prepared_ds = []
+        for ctx in data_source_contexts:
+            entry = {**ctx}
+            sample = ctx.get("sample_data")
+            entry["sample_data_json"] = (
+                json.dumps(sample, indent=2)[:_SAMPLE_DATA_MAX_CHARS] if sample is not None else None
+            )
+            prepared_ds.append(entry)
+
+    return render(
+        "followup.jinja2",
+        project_summary=project_summary,
+        file_tree=file_tree,
+        data_source_contexts=prepared_ds,
+    )

--- a/backend/src/flow44/ai/agents/followup/templates/followup.jinja2
+++ b/backend/src/flow44/ai/agents/followup/templates/followup.jinja2
@@ -6,6 +6,48 @@ You are an expert full-stack web developer assistant. You help users understand 
 ## File Tree
 {{ file_tree }}
 
+{% if data_source_contexts %}
+## Data Sources
+
+This project uses the following external data sources. Pre-built TypeScript modules
+exist at `src/dataSources/` — use `import { dataSource<Name> } from './dataSources/<Name>';`
+to call them.
+
+{% for ctx in data_source_contexts %}
+### {{ ctx.data_source_name }} (ID: {{ ctx.data_source_id }})
+{% if ctx.sanitized_name is defined and ctx.sanitized_name %}
+Module: `src/dataSources/{{ ctx.sanitized_name }}.ts`
+{% endif %}
+
+**Response schema:**
+{% for q in ctx.queries %}
+- `{{ q.name }}`{% if q.display_name %} ({{ q.display_name }}){% endif %}{% if q.description %} — {{ q.description }}{% endif %}
+
+{% for f in q.fields %}
+  - `{{ f.name }}` ({{ f.type }}){% if f.description %} — {{ f.description }}{% endif %}
+
+{% endfor %}
+{% endfor %}
+
+**Parameters:**
+{% if ctx.params_info and ctx.params_info.parameters %}
+{% for p in ctx.params_info.parameters %}
+- `{{ p.name }}` ({{ p.type }}{% if not p.is_single_value %}[]{% endif %}){% if p.is_required %} — required{% elif p.is_require_any %} — required (one of group){% else %} — optional{% endif %}
+
+{% endfor %}
+{% else %}
+None — call with no arguments.
+{% endif %}
+
+{% if ctx.sample_data_json %}
+**Sample response (truncated):**
+```json
+{{ ctx.sample_data_json }}
+```
+{% endif %}
+
+{% endfor %}
+{% endif %}
 ## How to Work
 
 Follow the EXPLORE → REASON → ACT pattern:

--- a/backend/src/flow44/ai/agents/plan/agent.py
+++ b/backend/src/flow44/ai/agents/plan/agent.py
@@ -214,7 +214,7 @@ class PlanAgent(BaseAgent):
         params_info = DataSourceParamsInfo.model_validate(context["params_info"])
         queries = [DataSourceQuerySchema.model_validate(q) for q in context.get("queries", [])]
         analysis = await self._analyze_data_source(
-            context["data_source_name"], context["sample_data"], queries, params_info  # type: ignore[arg-type]
+            context["data_source_name"], context["sample_data"], queries, params_info
         )
         return {**context, **analysis}
 

--- a/backend/src/flow44/ai/agents/plan/agent.py
+++ b/backend/src/flow44/ai/agents/plan/agent.py
@@ -15,7 +15,6 @@ from flow44.ai.agents.plan.prompts import (
     render_user_plan,
 )
 from flow44.ai.codegen.data_source_module import generate_data_source_module
-from flow44.ai.codegen.ts_types import sanitize_to_pascal_case
 from flow44.ai.core.flow import Flow
 from flow44.ai.core.messages import Message
 from flow44.ai.core.provider import complete_chat
@@ -208,22 +207,16 @@ class PlanAgent(BaseAgent):
     # -- Design --
 
     async def _fetch_and_analyze_data_source(self, data_source_id: str) -> dict[str, Any]:
-        ds_name, usage = await asyncio.gather(
-            ds_logic.get_display_name(data_source_id, authorization=self._data_source_authorization),
-            ds_logic.get_usage(data_source_id, authorization=self._data_source_authorization),
+        context = await ds_logic.build_data_source_context(
+            data_source_id, authorization=self._data_source_authorization
         )
-        sanitized = sanitize_to_pascal_case(ds_name) or f"DataSource{data_source_id}"
-        analysis = await self._analyze_data_source(ds_name, usage.sample, usage.queries, usage.params)
-        return {
-            "data_source_id": data_source_id,
-            "data_source_name": ds_name,
-            "sanitized_name": sanitized,
-            "queries": [q.model_dump() for q in usage.queries],
-            "params_info": usage.params.model_dump(),
-            "sample_data": usage.sample,
-            "can_run_without_input": usage.can_run,
-            **analysis,
-        }
+        # LLM analysis needs typed objects — reconstruct from the context dict
+        params_info = DataSourceParamsInfo.model_validate(context["params_info"])
+        queries = [DataSourceQuerySchema.model_validate(q) for q in context.get("queries", [])]
+        analysis = await self._analyze_data_source(
+            context["data_source_name"], context["sample_data"], queries, params_info  # type: ignore[arg-type]
+        )
+        return {**context, **analysis}
 
     @staticmethod
     def _generate_data_source_files(ctx: dict[str, Any]) -> dict[str, str]:

--- a/backend/src/flow44/api/chat.py
+++ b/backend/src/flow44/api/chat.py
@@ -142,6 +142,8 @@ async def chat_ws(  # noqa: C901, PLR0915
                         project_id=project.id,
                         sandbox=sandbox,
                         model=selected_model,
+                        data_source_authorization=data_source_authorization,
+                        data_source_ids=[str(dsid) for dsid in ds_ids] if ds_ids else None,
                     )
                     _start_agent(project.id, followup_agent.run(user_content))
 

--- a/backend/src/flow44/logic/data_source.py
+++ b/backend/src/flow44/logic/data_source.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from typing import Any
 
 from pydantic import ValidationError
 
@@ -32,6 +33,7 @@ __all__ = [
     "DataSourceResult",
     "DataSourceUsage",
     "FlapiUpstreamError",
+    "build_data_source_context",
     "can_run_without_params",
     "fetch_data_source",
     "get_display_name",
@@ -242,6 +244,34 @@ async def can_run_without_params(
     params_info = await get_params_info(data_source_id, authorization=authorization)
     minimal = _minimal_params_for(params_info)
     return minimal is not None, minimal
+
+
+async def build_data_source_context(
+    data_source_id: str | int,
+    *,
+    authorization: str | None = None,
+) -> dict[str, Any]:
+    """Build a datasource context dict with schema, params, and sample data.
+
+    Used by both the plan agent (which layers LLM analysis on top) and the
+    followup agent (which uses it directly for prompt context).
+    """
+    from flow44.ai.codegen.ts_types import sanitize_to_pascal_case  # noqa: PLC0415
+
+    name, usage = await asyncio.gather(
+        get_display_name(data_source_id, authorization=authorization),
+        get_usage(data_source_id, authorization=authorization),
+    )
+    sanitized = sanitize_to_pascal_case(name) or f"DataSource{data_source_id}"
+    return {
+        "data_source_id": str(data_source_id),
+        "data_source_name": name,
+        "sanitized_name": sanitized,
+        "queries": [q.model_dump() for q in usage.queries],
+        "params_info": usage.params.model_dump(),
+        "sample_data": usage.sample,
+        "can_run_without_input": usage.can_run,
+    }
 
 
 async def get_usage(


### PR DESCRIPTION
## Summary
- Followup agent now saves assistant responses (with compact tool-call log + files-changed) to `chat_messages`, fixing broken conversation memory
- Datasource context is now passed to the followup system prompt — both existing project datasources and newly attached ones
- Introduces `ChatAgent` base class shared by FollowUpAgent and FixErrorAgent
- Extracts `build_data_source_context()` as shared utility used by plan + followup agents

## Test plan
- [ ] Send a followup message → verify `chat_messages` has assistant row with tool log + answer
- [ ] Send another followup → confirm LLM sees interleaved user/assistant history
- [ ] Attach a datasource to a followup → confirm system prompt includes DS schema
- [ ] Trigger fix_error → confirm it also saves response
- [ ] Verify initial plan with datasources still works after refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)