### PR TITLE
PR 1: Configure pnpm 11 project installs

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 11
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 11
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 11
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,8 @@ dev-mocks: kill-port-$(DEV_PORT_MOCKS)
 # Install dependencies (also installs Husky git hooks)
 install:
 	cd frontend && pnpm install
-	cd mocks/flapi-mock && pnpm install
+	cd mocks/flapi-mock && pnpm clean --lockfile && pnpm install
+	cd backend/pnpm-project-template && pnpm clean --lockfile && pnpm install
 	cd backend && uv sync
 
 # Build Docker image

--- a/backend/pnpm-project-template/package.json
+++ b/backend/pnpm-project-template/package.json
@@ -21,5 +21,8 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.2.2",
     "vite": "^5.1.4"
+  },
+  "engines": {
+    "pnpm": ">=11.0.0 <12.0.0"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,5 +59,7 @@
     "@playwright/test": "^1.58.2",
     "playwright": "^1.58.2"
   },
-  "packageManager": "pnpm@10.6.5+sha512.cdf928fca20832cd59ec53826492b7dc25dc524d4370b6b4adbf65803d32efaa6c1c88147c0ae4e8d579a6c9eec715757b50d4fa35eea179d868eada4ed043af"
+  "engines": {
+    "pnpm": ">=11.0.0 <12.0.0"
+  }
 }

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+# pnpm 11+ requires explicit approval for dependency install scripts.
+allowBuilds:
+  esbuild: true

--- a/mocks/flapi-mock/package.json
+++ b/mocks/flapi-mock/package.json
@@ -15,7 +15,6 @@
     "@fastify/swagger-ui": "^5.2.6",
     "fastify": "^5.8.5"
   },
-  "packageManager": "pnpm@10.32.1+sha512.a706938f0e89ac1456b6563eab4edf1d1faf3368d1191fc5c59790e96dc918e4456ab2e67d613de1043d2e8c81f87303e6b40d4ffeca9df15ef1ad567348f2be",
   "devDependencies": {
     "@fastify/type-provider-typebox": "^6.1.0",
     "@sinclair/typebox": "^0.34.49",
@@ -23,5 +22,8 @@
     "nodemon": "^3.1.14",
     "tsx": "^4.21.0",
     "typescript": "^6.0.3"
+  },
+  "engines": {
+    "pnpm": ">=11.0.0 <12.0.0"
   }
 }

--- a/mocks/flapi-mock/pnpm-workspace.yaml
+++ b/mocks/flapi-mock/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+# pnpm 11+ requires explicit approval for dependency install scripts.
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Summary
- update frontend CI to pnpm 11
- require pnpm 11 for frontend, mocks, and the generated-app template
- approve esbuild install scripts for pnpm 11
- clean and install mock/template dependencies from `make install`

## Validation
- `git diff --cached --check`
- frontend `pnpm install --frozen-lockfile --offline`
- package JSON and YAML parsing