### PR TITLE
PR 2: Add optional package support for generated apps

### DIFF
--- a/backend/src/flow44/ai/agents/execute/agent.py
+++ b/backend/src/flow44/ai/agents/execute/agent.py
@@ -5,19 +5,37 @@ import uuid
 
 from langfuse import Langfuse
 from langfuse.decorators import langfuse_context, observe
+from pydantic import ValidationError
 
 from flow44.ai.agents._base import BaseAgent
 from flow44.ai.agents.execute.execution_state import ExecutionState
 from flow44.ai.agents.execute.models import Task, WorkPlan
+from flow44.ai.agents.execute.optional_packages import (
+    OptionalPackageDecision,
+    allowed_import_names,
+    high_confidence_optional_package_decision,
+    merge_optional_package_decisions,
+    package_capabilities,
+    package_install_names,
+    repair_unselected_package_references,
+    selected_package_names,
+    validate_optional_package_decision,
+)
 from flow44.ai.agents.execute.prompts import (
     SUMMARY_PROMPT,
     render_codegen,
     render_fix_errors,
     render_merge,
+    render_package_decision,
 )
 from flow44.ai.core.flow import Flow
 from flow44.ai.core.messages import Message
 from flow44.ai.core.provider import complete_chat, stream_chat
+from flow44.ai.generated_app_contract import (
+    GeneratedAppContractError,
+    assert_generated_app_file_allowed,
+    assert_generated_code_contract,
+)
 from flow44.ai.helpers import parse_json_response
 from flow44.ai.parser import ActionParser
 from flow44.ai.state import BuildState
@@ -133,6 +151,9 @@ class ExecuteAgent(BaseAgent):
         if state.build_state.work_plan is None:
             raise RuntimeError("No work plan available")
 
+        await state.sandbox_ref.enable_optional_packages(
+            package_install_names(state.build_state.work_plan.selected_packages)
+        )
         span = state.langfuse_client.span(
             trace_id=state.trace_id,
             name="execute-plan",
@@ -178,7 +199,13 @@ class ExecuteAgent(BaseAgent):
         await state.emit_fn({"type": "phase", "phase": "fixing"})
         state.fix_attempts += 1
 
-        prompt = render_fix_errors(errors=state.all_errors, files=state.build_state.completed_files)
+        selected_packages = state.build_state.work_plan.selected_packages if state.build_state.work_plan else []
+        await state.sandbox_ref.enable_optional_packages(package_install_names(selected_packages))
+        prompt = render_fix_errors(
+            errors=state.all_errors,
+            files=state.build_state.completed_files,
+            selected_packages=selected_packages,
+        )
         try:
             generated: list[tuple[str, str]] = []
             parser = ActionParser(on_file_action=lambda p, c: generated.append((p, c)))
@@ -192,7 +219,11 @@ class ExecuteAgent(BaseAgent):
                 parser.feed(chunk)
             parser.flush()
 
-            for path, content in generated:
+            validated = [
+                (assert_generated_code_contract(path, content, allowed_import_names(selected_packages)), content)
+                for path, content in generated
+            ]
+            for path, content in validated:
                 await state.sandbox_ref.write_file(path, content)
                 state.build_state.completed_files[path] = content
                 await state.emit_fn({"type": "file", "path": path, "content": content})
@@ -236,11 +267,19 @@ class ExecuteAgent(BaseAgent):
 
     async def _build_technical_plan(self, state: ExecutionState) -> WorkPlan:
         """Build technical task plan from user overview."""
+        decision = await self._decide_optional_packages(state)
+        selected_packages = selected_package_names(decision)
+        await state.sandbox_ref.enable_optional_packages(package_install_names(selected_packages))
+
         merge_data: dict[str, object] = {
             "user_request": state.build_state.user_content,
             "architecture": state.build_state.architecture.model_dump(),
             "ux_design": state.build_state.ux_design.model_dump(),
             "user_preferences": [d.model_dump() for d in state.build_state.user_overview.decisions],
+            "optional_package_decision": {
+                "selected_packages": [package.model_dump() for package in decision.selected_packages],
+                "selected_capabilities": package_capabilities(selected_packages),
+            },
         }
         if state.build_state.data_source_contexts:
             merge_data["data_source_integrations"] = [
@@ -264,30 +303,77 @@ class ExecuteAgent(BaseAgent):
 
         raw = await complete_chat(
             [Message.user(json.dumps(merge_data, indent=2))],
-            render_merge(has_data_sources=bool(state.build_state.data_source_contexts)),
+            render_merge(
+                has_data_sources=bool(state.build_state.data_source_contexts),
+                selected_packages=selected_packages,
+            ),
             model=state.model,
             metadata=state.llm_metadata_fn("build_technical_plan"),
         )
         plan_data = parse_json_response(raw)
 
-        tasks = [
-            Task(
-                id=t.get("id", f"task-{uuid.uuid4().hex[:6]}"),
-                title=t.get("title", "Untitled task"),
-                description=t.get("description", ""),
-                files=t.get("files", []),
-                depends_on=t.get("depends_on", []),
+        tasks: list[Task] = []
+        for task_data in plan_data.get("tasks", []):
+            safe_files: list[str] = []
+            for path in task_data.get("files", []):
+                try:
+                    safe_files.append(assert_generated_app_file_allowed(path))
+                except GeneratedAppContractError:
+                    logger.warning("[execute] Dropping protected file from generated plan: %s", path)
+            if not safe_files:
+                continue
+            tasks.append(
+                Task(
+                    id=task_data.get("id", f"task-{uuid.uuid4().hex[:6]}"),
+                    title=repair_unselected_package_references(
+                        task_data.get("title", "Untitled task"), selected_packages
+                    ),
+                    description=repair_unselected_package_references(
+                        task_data.get("description", ""), selected_packages
+                    ),
+                    files=safe_files,
+                    depends_on=task_data.get("depends_on", []),
+                )
             )
-            for t in plan_data.get("tasks", [])
-        ]
+
+        task_ids = {task.id for task in tasks}
+        for task in tasks:
+            task.depends_on = [dependency for dependency in task.depends_on if dependency in task_ids]
 
         return WorkPlan(
             id=f"plan-{uuid.uuid4().hex[:8]}",
-            summary=plan_data.get("summary", ""),
+            summary=repair_unselected_package_references(plan_data.get("summary", ""), selected_packages),
             architecture=state.build_state.architecture,
             ux_design=state.build_state.ux_design,
             tasks=tasks,
+            selected_packages=selected_packages,
         )
+
+    async def _decide_optional_packages(self, state: ExecutionState) -> OptionalPackageDecision:
+        decision_input = json.dumps(
+            {
+                "user_request": state.build_state.user_content,
+                "architecture": state.build_state.architecture.model_dump(),
+                "ux_design": state.build_state.ux_design.model_dump(),
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+        raw = await complete_chat(
+            [Message.user(decision_input)],
+            render_package_decision(),
+            model=state.model,
+            metadata=state.llm_metadata_fn("decide_optional_packages"),
+        )
+        try:
+            decision = OptionalPackageDecision.model_validate(parse_json_response(raw))
+            return merge_optional_package_decisions(
+                validate_optional_package_decision(decision),
+                high_confidence_optional_package_decision(state.build_state.user_content),
+            )
+        except ValidationError:
+            logger.warning("[execute] Invalid optional package decision; using high-confidence package signals")
+            return high_confidence_optional_package_decision(state.build_state.user_content)
 
     async def _execute_task(self, task: Task, state: ExecutionState) -> None:
         """Execute a single task with Langfuse span."""
@@ -319,6 +405,7 @@ class ExecuteAgent(BaseAgent):
                 other_completed_files={p: c for p, c in state.build_state.completed_files.items() if p not in dep_paths}
                 or None,
                 data_source_contexts=state.build_state.data_source_contexts or None,
+                selected_packages=state.build_state.work_plan.selected_packages,
             )
 
             generated: list[tuple[str, str]] = []
@@ -333,8 +420,19 @@ class ExecuteAgent(BaseAgent):
                 parser.feed(chunk)
             parser.flush()
 
-            paths: list[str] = []
+            expected_paths = {assert_generated_app_file_allowed(path) for path in task.files}
+            allowed_imports = allowed_import_names(state.build_state.work_plan.selected_packages)
+            validated: list[tuple[str, str]] = []
             for path, content in generated:
+                normalized_path = assert_generated_code_contract(path, content, allowed_imports)
+                if normalized_path not in expected_paths:
+                    raise GeneratedAppContractError(
+                        f"Generated unexpected file outside task contract: {normalized_path}"
+                    )
+                validated.append((normalized_path, content))
+
+            paths: list[str] = []
+            for path, content in validated:
                 await state.sandbox_ref.write_file(path, content)
                 state.build_state.completed_files[path] = content
                 paths.append(path)

--- a/backend/src/flow44/ai/agents/execute/models.py
+++ b/backend/src/flow44/ai/agents/execute/models.py
@@ -29,6 +29,7 @@ class WorkPlan(BaseModel):
     architecture: ArchitectureDesign
     ux_design: UXDesign
     tasks: list[Task]
+    selected_packages: list[str] = Field(default_factory=list)
 
     def execution_layers(self) -> list[list[Task]]:
         """Return tasks grouped by dependency layers for parallel execution."""

--- a/backend/src/flow44/ai/agents/execute/optional_packages.py
+++ b/backend/src/flow44/ai/agents/execute/optional_packages.py
@@ -1,0 +1,222 @@
+"""Whitelisted optional npm packages for generated apps."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class OptionalPackagePrompt(StrEnum):
+    CODEGEN_CONTEXT = "codegen_context"
+    CODEGEN_RULES = "codegen_rules"
+    CODEGEN_UNSELECTED_RULES = "codegen_unselected_rules"
+    MERGE_RULES = "merge_rules"
+    MERGE_UNSELECTED_RULES = "merge_unselected_rules"
+    FIX_ERRORS_RULES = "fix_errors_rules"
+    FIX_ERRORS_UNSELECTED_RULES = "fix_errors_unselected_rules"
+
+
+@dataclass(frozen=True)
+class OptionalPackage:
+    name: str
+    capability: str
+    packages: tuple[str, ...]
+    use_when: str
+    avoid_when: str
+    strong_intent_groups: tuple[tuple[str, ...], ...] = ()
+    template_dir: str | None = None
+
+    @property
+    def prompt_dir(self) -> str:
+        return self.template_dir or self.name
+
+    def prompt_template(self, prompt: OptionalPackagePrompt) -> str:
+        return f"optional_packages/{self.prompt_dir}/{prompt.value}.jinja2"
+
+
+OPTIONAL_PACKAGES: dict[str, OptionalPackage] = {
+    "mui": OptionalPackage(
+        name="mui",
+        capability="material_ui_components",
+        packages=("@mui/material", "@emotion/react", "@emotion/styled"),
+        use_when=(
+            "Use when the user explicitly asks for Material UI or MUI, or when the app needs a broad set of "
+            "polished Material Design controls such as dialogs, menus, drawers, data-entry controls, and "
+            "consistent accessible components."
+        ),
+        avoid_when=(
+            "Avoid when Tailwind and basic React components are sufficient, when the user asks for another "
+            "design system, or when Material Design would conflict with the requested visual style."
+        ),
+        strong_intent_groups=(("material ui",), ("mui",)),
+    ),
+    "recharts": OptionalPackage(
+        name="recharts",
+        capability="dashboard_charts",
+        packages=("recharts",),
+        use_when=(
+            "Use when the user requests dashboard charts, data visualization, trends, comparisons, "
+            "time-series charts, bar charts, line charts, area charts, or pie charts."
+        ),
+        avoid_when=(
+            "Do not use for maps, relationship graphs, node-edge diagrams, plain numeric KPI cards, "
+            "or data that is clearer as a simple table or list."
+        ),
+        strong_intent_groups=(
+            ("chart",),
+            ("data visualization",),
+            ("time series",),
+            ("trend", "graph"),
+            ("dashboard", "chart"),
+        ),
+    ),
+}
+
+
+class SelectedOptionalPackage(BaseModel):
+    name: str
+    capability: str = ""
+    reason: str = ""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_legacy_package_key(cls, data: dict[str, object]) -> dict[str, object]:
+        if "name" not in data and "package" in data:
+            return data | {"name": data["package"]}
+        return data
+
+
+class OptionalPackageDecision(BaseModel):
+    selected_packages: list[SelectedOptionalPackage] = Field(default_factory=list)
+
+
+def optional_package_prompt_context() -> list[dict[str, str]]:
+    return [
+        {
+            "name": package.name,
+            "capability": package.capability,
+            "use_when": package.use_when,
+            "avoid_when": package.avoid_when,
+        }
+        for package in OPTIONAL_PACKAGES.values()
+    ]
+
+
+def validate_optional_package_decision(decision: OptionalPackageDecision) -> OptionalPackageDecision:
+    """Canonicalize model output, preserving the first valid reason for each selected package."""
+    selected: list[SelectedOptionalPackage] = []
+    seen: set[str] = set()
+    for item in decision.selected_packages:
+        if item.name not in OPTIONAL_PACKAGES or item.name in seen:
+            continue
+        package = OPTIONAL_PACKAGES[item.name]
+        selected.append(
+            SelectedOptionalPackage(
+                name=package.name,
+                capability=package.capability,
+                reason=item.reason.strip(),
+            )
+        )
+        seen.add(item.name)
+    return OptionalPackageDecision(selected_packages=selected)
+
+
+def high_confidence_optional_package_decision(user_request: str) -> OptionalPackageDecision:
+    """Select packages for explicit, high-confidence registry-owned intent signals."""
+    normalized_request = user_request.casefold()
+    selected = [
+        SelectedOptionalPackage(
+            name=package.name,
+            capability=package.capability,
+            reason=f"Explicit request matches the {package.capability} capability.",
+        )
+        for package in OPTIONAL_PACKAGES.values()
+        if any(
+            all(signal.casefold() in normalized_request for signal in group) for group in package.strong_intent_groups
+        )
+    ]
+    return OptionalPackageDecision(selected_packages=selected)
+
+
+def merge_optional_package_decisions(*decisions: OptionalPackageDecision) -> OptionalPackageDecision:
+    """Merge decisions in priority order, preserving first valid reasons and deduplicating names."""
+    return validate_optional_package_decision(
+        OptionalPackageDecision(
+            selected_packages=[item for decision in decisions for item in decision.selected_packages]
+        )
+    )
+
+
+def selected_package_names(decision: OptionalPackageDecision) -> list[str]:
+    """Extract package names from model output and keep only whitelisted packages."""
+    return [item.name for item in validate_optional_package_decision(decision).selected_packages]
+
+
+def validate_optional_packages(package_names: list[str]) -> list[str]:
+    """Return unique whitelisted package names in selection order."""
+    selected: list[str] = []
+    seen: set[str] = set()
+    for name in package_names:
+        if name not in OPTIONAL_PACKAGES or name in seen:
+            continue
+        selected.append(name)
+        seen.add(name)
+    return selected
+
+
+def package_install_names(package_names: list[str]) -> list[str]:
+    packages: list[str] = []
+    seen: set[str] = set()
+    for name in validate_optional_packages(package_names):
+        for package_name in OPTIONAL_PACKAGES[name].packages:
+            if package_name in seen:
+                continue
+            packages.append(package_name)
+            seen.add(package_name)
+    return packages
+
+
+def allowed_import_names(package_names: list[str]) -> list[str]:
+    """Return the external import specifiers made available by selected packages."""
+    return package_install_names(package_names)
+
+
+def selected_packages_from_package_json(package_json: str) -> list[str]:
+    """Recover selected whitelisted packages from installed dependency declarations."""
+    import json  # noqa: PLC0415
+
+    try:
+        parsed = json.loads(package_json)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    dependencies = parsed.get("dependencies", {})
+    if not isinstance(dependencies, dict):
+        return []
+    return [
+        name
+        for name, package in OPTIONAL_PACKAGES.items()
+        if all(package_name in dependencies for package_name in package.packages)
+    ]
+
+
+def repair_unselected_package_references(text: str, selected_packages: list[str]) -> str:
+    """Replace known unselected optional-package plan references with a browser fallback."""
+    selected = set(validate_optional_packages(selected_packages))
+    repaired = text
+    for name, package in OPTIONAL_PACKAGES.items():
+        if name in selected:
+            continue
+        for reference in {name, *package.packages}:
+            repaired = re.sub(re.escape(reference), "React/browser fallback", repaired, flags=re.IGNORECASE)
+    return repaired
+
+
+def has_capability(package_names: list[str], capability: str) -> bool:
+    return any(OPTIONAL_PACKAGES[name].capability == capability for name in validate_optional_packages(package_names))
+
+
+def package_capabilities(package_names: list[str]) -> list[str]:
+    return [OPTIONAL_PACKAGES[name].capability for name in validate_optional_packages(package_names)]

--- a/backend/src/flow44/ai/agents/execute/prompts.py
+++ b/backend/src/flow44/ai/agents/execute/prompts.py
@@ -5,7 +5,15 @@ import re
 from pathlib import Path
 from typing import Any
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, TemplateNotFound
+
+from flow44.ai.agents.execute.optional_packages import (
+    OPTIONAL_PACKAGES,
+    OptionalPackagePrompt,
+    allowed_import_names,
+    optional_package_prompt_context,
+    validate_optional_packages,
+)
 
 _templates_dir = Path(__file__).parent / "templates"
 _env = Environment(  # noqa: S701 — templates are LLM prompts, not HTML; autoescape would break them
@@ -17,8 +25,20 @@ def render(template_name: str, **kwargs: Any) -> str:
     return _env.get_template(template_name).render(**kwargs)
 
 
-def render_merge(*, has_data_sources: bool = False) -> str:
-    return render("merge.jinja2", has_data_sources=has_data_sources)
+def render_merge(*, has_data_sources: bool = False, selected_packages: list[str] | None = None) -> str:
+    validated_packages = validate_optional_packages(selected_packages or [])
+    return render(
+        "merge.jinja2",
+        has_data_sources=has_data_sources,
+        package_merge_rules=_render_optional_package_prompts(validated_packages, OptionalPackagePrompt.MERGE_RULES),
+        package_unselected_merge_rules=_render_unselected_optional_package_prompts(
+            validated_packages, OptionalPackagePrompt.MERGE_UNSELECTED_RULES
+        ),
+    )
+
+
+def render_package_decision() -> str:
+    return render("package_decision.jinja2", optional_packages=optional_package_prompt_context())
 
 
 def render_summary() -> str:
@@ -35,6 +55,7 @@ def render_codegen(  # noqa: PLR0913
     dependency_files: dict[str, str] | None = None,
     other_completed_files: dict[str, str] | None = None,
     data_source_contexts: list[dict[str, Any]] | None = None,
+    selected_packages: list[str] | None = None,
 ) -> str:
     prepared_sources = None
     if data_source_contexts:
@@ -62,6 +83,7 @@ def render_codegen(  # noqa: PLR0913
                     preview += f"\n... ({len(lines) - 50} more lines)"
                 other_exports[path] = preview
 
+    validated_packages = validate_optional_packages(selected_packages or [])
     return render(
         "codegen.jinja2",
         task_title=task_title,
@@ -72,11 +94,56 @@ def render_codegen(  # noqa: PLR0913
         dependency_files=dependency_files,
         other_completed_exports=other_exports,
         data_source_contexts=prepared_sources,
+        allowed_imports=allowed_import_names(validated_packages),
+        package_contexts=_render_optional_package_prompts(validated_packages, OptionalPackagePrompt.CODEGEN_CONTEXT),
+        package_rules=_render_optional_package_prompts(validated_packages, OptionalPackagePrompt.CODEGEN_RULES),
+        package_unselected_rules=_render_unselected_optional_package_prompts(
+            validated_packages, OptionalPackagePrompt.CODEGEN_UNSELECTED_RULES
+        ),
     )
 
 
-def render_fix_errors(*, errors: str, files: dict[str, str]) -> str:
-    return render("fix_errors.jinja2", errors=errors, files=files)
+def render_fix_errors(*, errors: str, files: dict[str, str], selected_packages: list[str] | None = None) -> str:
+    validated_packages = validate_optional_packages(selected_packages or [])
+    return render(
+        "fix_errors.jinja2",
+        errors=errors,
+        files=files,
+        allowed_imports=allowed_import_names(validated_packages),
+        package_fix_rules=_render_optional_package_prompts(validated_packages, OptionalPackagePrompt.FIX_ERRORS_RULES),
+        package_unselected_fix_rules=_render_unselected_optional_package_prompts(
+            validated_packages, OptionalPackagePrompt.FIX_ERRORS_UNSELECTED_RULES
+        ),
+    )
+
+
+def _render_optional_package_prompts(
+    selected_packages: list[str] | None,
+    prompt: OptionalPackagePrompt,
+) -> list[str]:
+    blocks: list[str] = []
+    for package_name in validate_optional_packages(selected_packages or []):
+        try:
+            blocks.append(render(OPTIONAL_PACKAGES[package_name].prompt_template(prompt)).strip())
+        except TemplateNotFound:
+            continue
+    return blocks
+
+
+def _render_unselected_optional_package_prompts(
+    selected_packages: list[str] | None,
+    prompt: OptionalPackagePrompt,
+) -> list[str]:
+    selected = set(validate_optional_packages(selected_packages or []))
+    blocks: list[str] = []
+    for package_name, package in OPTIONAL_PACKAGES.items():
+        if package_name in selected:
+            continue
+        try:
+            blocks.append(render(package.prompt_template(prompt)).strip())
+        except TemplateNotFound:
+            continue
+    return blocks
 
 
 def _extract_exports(content: str) -> str:

--- a/backend/src/flow44/ai/agents/execute/templates/_dependency_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/_dependency_rules.jinja2
@@ -1,0 +1,15 @@
+## Dependency Rules
+
+Allowed imports:
+- React / React DOM
+- Browser APIs
+- Local project files
+{% for package in allowed_imports %}
+- {{ package }}
+{% endfor %}
+
+Forbidden:
+- Do not import unselected packages.
+- Do not edit `package.json`.
+- Do not install dependencies.
+- Do not use extra npm packages unless they are selected and listed above.

--- a/backend/src/flow44/ai/agents/execute/templates/_file_safety_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/_file_safety_rules.jinja2
@@ -1,0 +1,34 @@
+## File Safety Rules
+
+Default:
+- You may edit normal app source files needed for the user request.
+- Keep changes focused.
+- Preserve existing behavior unless the task requires changing it.
+- Be careful with shared/core files.
+
+Do not touch:
+- `package.json` or lock files
+- `vite.config.ts`
+- `index.html`
+- env files
+- `src/main.tsx`
+- `src/platform/*`
+- template guard files
+- CI/CD files
+- backend/server files
+- deployment/infrastructure files
+
+Edit only when clearly needed:
+- `src/App.tsx`
+- shared layout files
+- shared mock data/type files
+- global CSS files
+
+Free to edit:
+- `src/components/*`
+- `src/pages/*`
+- `src/data/*`
+- `src/lib/*`
+- `src/hooks/*`
+- `src/types/*`
+- feature-specific app files

--- a/backend/src/flow44/ai/agents/execute/templates/codegen.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/codegen.jinja2
@@ -109,13 +109,42 @@ placeholders or ellipses.
   </flowAction>
 </flowArtifact>
 ```
+{% if package_contexts %}
 
-Rules:
+## Optional Package Context
+
+{% for context in package_contexts %}
+{{ context }}
+{% endfor %}
+{% endif %}
+
+## General Rules
+
 1. All file paths are relative to the project root (e.g. src/App.tsx).
 2. Use TypeScript, React 18+, and Tailwind CSS v3.
 3. Tailwind CSS is pre-configured - use utility classes extensively for styling.
 4. Write clean, production-quality code with modern, polished UI/UX.
-5. Only output the files listed above — do not create extra files. Do NOT overwrite `src/auth`, `src/api`, `src/dataSources`, `src/config.ts` or `src/main.tsx` — they are pre-configured or generated.
-6. **CRITICAL**: Only React, TypeScript, and Tailwind CSS are available. Do NOT use or import other npm packages (no axios, lodash, zustand, date-fns, clsx, etc.). All functionality must be implemented using built-in browser APIs and the pre-installed packages only.
+5. Only output the files listed above — do not create extra files.
+6. Keep changes small and focused.
 7. Import from already-completed files using their exact export names.
 8. Do NOT include shell actions — only file actions.
+
+{% include "_file_safety_rules.jinja2" %}
+
+{% include "_dependency_rules.jinja2" %}
+{% if package_rules %}
+
+## Selected Package Rules
+
+{% for rule_block in package_rules %}
+{{ rule_block }}
+{% endfor %}
+{% endif %}
+{% if package_unselected_rules %}
+
+## Unselected Package Rules
+
+{% for rule_block in package_unselected_rules %}
+{{ rule_block }}
+{% endfor %}
+{% endif %}

--- a/backend/src/flow44/ai/agents/execute/templates/fix_errors.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/fix_errors.jinja2
@@ -30,3 +30,21 @@ Rules:
 2. Do NOT change functionality — only fix type errors.
 3. Output complete file contents, not patches.
 4. Do NOT include shell actions.
+
+{% include "_file_safety_rules.jinja2" %}
+
+{% include "_dependency_rules.jinja2" %}
+{% if package_fix_rules %}
+
+Package-specific repair rules:
+{% for rule_block in package_fix_rules %}
+{{ rule_block }}
+{% endfor %}
+{% endif %}
+{% if package_unselected_fix_rules %}
+
+Package-specific fallback repair rules:
+{% for rule_block in package_unselected_fix_rules %}
+{{ rule_block }}
+{% endfor %}
+{% endif %}

--- a/backend/src/flow44/ai/agents/execute/templates/merge.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/merge.jinja2
@@ -4,6 +4,7 @@ You will receive:
 1. The original user request
 2. An architecture design (JSON)
 3. A UI/UX design (JSON)
+4. An optional package decision (JSON)
 
 Create a task list where each task produces one or more files. Tasks should be ordered so that foundational files (types, utilities, hooks) come first, then components, then the main App integration.
 
@@ -37,9 +38,24 @@ Rules:
 - Component tasks depend on their type definitions
 - The final App.tsx integration task depends on all component tasks
 - Keep the total number of tasks reasonable (3-10 for most projects)
-- Do NOT create tasks for modifying package.json - only the pre-configured packages are available (React, TypeScript, Vite, Tailwind CSS)
 - Do NOT include tasks for installing dependencies or running the dev server
-- Do NOT include `src/config.ts` in any task's files — it is pre-configured and must not be overwritten
+- Do NOT plan imports from packages that are not selected in the optional package decision or not installed in the project
+
+{% include "_file_safety_rules.jinja2" %}
+{% if package_merge_rules %}
+
+Package-specific task planning rules:
+{% for rule_block in package_merge_rules %}
+{{ rule_block }}
+{% endfor %}
+{% endif %}
+{% if package_unselected_merge_rules %}
+
+Package-specific fallback planning rules:
+{% for rule_block in package_unselected_merge_rules %}
+{{ rule_block }}
+{% endfor %}
+{% endif %}
 {% if has_data_sources %}
 
 ## Data Source Integration — Pre-Generated Files

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/README.md
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/README.md
@@ -1,0 +1,41 @@
+# Optional Package Prompt Templates
+
+Optional npm packages are whitelisted in `flow44.ai.agents.execute.optional_packages`.
+Each package can own prompt fragments under this folder.
+Prompt fragments are loaded by `OptionalPackagePrompt` in `optional_packages.py`, so each filename maps to one prompt scenario.
+
+## Directory Layout
+
+Use one folder per optional package:
+
+```text
+templates/optional_packages/<package-name>/
+  codegen_context.jinja2      # Implementation context rendered before codegen Rules
+  codegen_rules.jinja2        # Implementation rules rendered inside codegen Rules
+  merge_rules.jinja2          # Planning guidance rendered only in merge prompts
+  fix_errors_rules.jinja2     # Repair guidance rendered only in fix-error prompts
+```
+
+Only create the files a package needs. Missing files are ignored.
+
+## Add A Package
+
+1. Add one entry to `OPTIONAL_PACKAGES` in `optional_packages.py`.
+2. Set `name` to the npm package key used by package decisions.
+3. Set `packages` to the npm packages that should be installed.
+4. Set `capability`, `use_when`, and `avoid_when` for the package decision prompt.
+5. Add package prompt fragments in `templates/optional_packages/<name>/` only for the prompt scenarios that need package-specific guidance.
+
+Example:
+
+```python
+"mui": OptionalPackage(
+    name="mui",
+    capability="material_ui_components",
+    packages=("@mui/material", "@emotion/react", "@emotion/styled"),
+    use_when="Use when the user explicitly asks for Material UI or MUI.",
+    avoid_when="Do not use when Tailwind and basic React components are sufficient.",
+),
+```
+
+If the prompt folder name cannot match the npm package name, set `template_dir`.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/mui/codegen_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/mui/codegen_rules.jinja2
@@ -1,0 +1,8 @@
+Required:
+- Import Material UI components from `@mui/material`.
+- Prefer MUI components and the `sx` prop for cohesive Material Design UI when MUI is selected.
+- Keep theme customization local unless the task explicitly requires an app-wide theme.
+
+Forbidden:
+- Do not import deprecated `@mui/styles`.
+- Do not mix in another component library unless it is separately selected and installed.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/mui/fix_errors_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/mui/fix_errors_rules.jinja2
@@ -1,0 +1,4 @@
+MUI rules:
+- Fix MUI usage in app source files only. Do not edit package manager files.
+- Import components from `@mui/material` and styling utilities from supported MUI or Emotion entry points.
+- Replace imports from deprecated `@mui/styles` with the `sx` prop, `styled`, or supported theme utilities.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/recharts/codegen_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/recharts/codegen_rules.jinja2
@@ -1,0 +1,9 @@
+Required:
+- Use Recharts components from `recharts` for dashboard charts and common data visualization.
+- Wrap responsive charts in `ResponsiveContainer` inside a parent with explicit height.
+- Use clear axis labels, tooltips, legends, and accessible colors when they improve comprehension.
+- Keep chart data typed and transform raw data before rendering when needed.
+
+Forbidden:
+- Do not use Recharts for maps, relationship graphs, or node-edge diagrams.
+- Do not add another charting package.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/recharts/fix_errors_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/recharts/fix_errors_rules.jinja2
@@ -1,0 +1,4 @@
+Recharts rules:
+- Import chart components from `recharts`.
+- If a responsive chart is blank, verify that its parent has an explicit height.
+- Keep chart data shapes aligned with each component's `dataKey` values.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/recharts/merge_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/recharts/merge_rules.jinja2
@@ -1,0 +1,3 @@
+- `recharts` is selected: plan focused chart components and any required data transformation.
+- Choose chart types that fit the requested comparison, trend, composition, or distribution.
+- Do not plan maps, relationship graphs, or dependency visualizations with Recharts.

--- a/backend/src/flow44/ai/agents/execute/templates/package_decision.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/package_decision.jinja2
@@ -1,0 +1,41 @@
+You decide which optional packages are useful for this app.
+
+Return JSON only.
+
+## Allowed Optional Packages
+
+{% for package in optional_packages %}
+### {{ package.name }}
+
+Capability:
+- {{ package.capability }}
+
+Use when: {{ package.use_when }}
+Avoid when: {{ package.avoid_when }}
+{% endfor %}
+
+## Selection Rules
+
+Required:
+- Select zero, one, or multiple packages from the allowed list.
+- Select every allowed package that is clearly useful for the requested app.
+- Use more than one package when the app clearly needs multiple package capabilities.
+- Use the package-specific guidance above.
+- Understand the user intent even if the request is written in another language.
+- If no package is clearly useful, return an empty list.
+
+Forbidden:
+- Do not select packages outside the allowed list.
+- Do not select a package only because it is available.
+- Do not select packages for features that are simple to build without them.
+
+## Output
+
+Return exactly this JSON shape:
+{"selected_packages":[{"name":"package-name","reason":"short reason based on the user request"}]}
+
+If no package is needed:
+{"selected_packages":[]}
+
+Important:
+- JSON only.

--- a/backend/src/flow44/ai/agents/fix_error/agent.py
+++ b/backend/src/flow44/ai/agents/fix_error/agent.py
@@ -4,11 +4,17 @@ from pathlib import PurePosixPath
 from langfuse.decorators import observe
 
 from flow44.ai.agents._base import BaseAgent
+from flow44.ai.agents.execute.optional_packages import (
+    allowed_import_names,
+    package_install_names,
+    selected_packages_from_package_json,
+)
 from flow44.ai.agents.fix_error.fix_error_state import FixErrorState
 from flow44.ai.agents.fix_error.prompts import render_fix_error_direct, render_fix_errors
 from flow44.ai.core.flow import Flow
 from flow44.ai.core.messages import Message
 from flow44.ai.core.provider import stream_chat
+from flow44.ai.generated_app_contract import assert_generated_code_contract
 from flow44.ai.parser import ActionParser
 from flow44.sandbox.main import PnpmSandbox
 
@@ -112,12 +118,14 @@ class FixErrorAgent(BaseAgent):
             {"type": "fix_step", "step": "generate", "status": "running", "message": "Generating fix with AI..."}
         )
 
+        state.selected_packages = await self._prepare_optional_packages()
         prompt = render_fix_error_direct(
             error_message=state.error_message,
             error_file=state.error_file,
             error_line=state.error_line,
             error_stack=state.error_stack,
             files=state.discovered_files,
+            selected_packages=state.selected_packages,
         )
 
         parser = ActionParser(on_file_action=lambda p, c: state.generated_files.append((p, c)))
@@ -166,6 +174,10 @@ class FixErrorAgent(BaseAgent):
             {"type": "fix_step", "step": "write", "status": "running", "message": "Writing fixed files..."}
         )
 
+        state.generated_files = [
+            (assert_generated_code_contract(path, content, allowed_import_names(state.selected_packages)), content)
+            for path, content in state.generated_files
+        ]
         for path, content in state.generated_files:
             await state.sandbox_ref.write_file(path, content)
             await state.emit_fn({"type": "file", "path": path, "content": content})
@@ -216,7 +228,12 @@ class FixErrorAgent(BaseAgent):
             {"type": "fix_step", "step": "retry", "status": "running", "message": "Attempting auto-fix..."}
         )
 
-        prompt = render_fix_errors(errors=state.validation_errors, files=dict(state.generated_files))
+        await state.sandbox_ref.enable_optional_packages(package_install_names(state.selected_packages))
+        prompt = render_fix_errors(
+            errors=state.validation_errors,
+            files=dict(state.generated_files),
+            selected_packages=state.selected_packages,
+        )
         generated: list[tuple[str, str]] = []
         parser = ActionParser(on_file_action=lambda p, c: generated.append((p, c)))
 
@@ -230,12 +247,16 @@ class FixErrorAgent(BaseAgent):
                 parser.feed(chunk)
             parser.flush()
 
-            for path, content in generated:
+            validated = [
+                (assert_generated_code_contract(path, content, allowed_import_names(state.selected_packages)), content)
+                for path, content in generated
+            ]
+            for path, content in validated:
                 await state.sandbox_ref.write_file(path, content)
                 await state.emit_fn({"type": "file", "path": path, "content": content})
 
             # Update generated files list
-            state.generated_files = generated
+            state.generated_files = validated
 
             await state.emit_fn(
                 {"type": "fix_step", "step": "retry", "status": "completed", "message": "Auto-fix applied"}
@@ -316,3 +337,12 @@ class FixErrorAgent(BaseAgent):
     async def _build(self) -> str:
         result = await self.sandbox.run_build_command("pnpm build")
         return result.errors
+
+    async def _prepare_optional_packages(self) -> list[str]:
+        try:
+            package_json = await self.sandbox.read_file("package.json")
+        except (FileNotFoundError, PermissionError):
+            return []
+        selected_packages = selected_packages_from_package_json(package_json)
+        await self.sandbox.enable_optional_packages(package_install_names(selected_packages))
+        return selected_packages

--- a/backend/src/flow44/ai/agents/fix_error/fix_error_state.py
+++ b/backend/src/flow44/ai/agents/fix_error/fix_error_state.py
@@ -24,6 +24,7 @@ class FixErrorState(BaseModel):
     # Working state
     discovered_files: dict[str, str] = Field(default_factory=dict)
     generated_files: list[tuple[str, str]] = Field(default_factory=list)
+    selected_packages: list[str] = Field(default_factory=list)
     full_response: str = ""
     validation_errors: str = ""
     retry_count: int = 0

--- a/backend/src/flow44/ai/agents/fix_error/prompts.py
+++ b/backend/src/flow44/ai/agents/fix_error/prompts.py
@@ -3,11 +3,21 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import ChoiceLoader, Environment, FileSystemLoader, TemplateNotFound
+
+from flow44.ai.agents.execute.optional_packages import (
+    OPTIONAL_PACKAGES,
+    OptionalPackagePrompt,
+    allowed_import_names,
+    validate_optional_packages,
+)
 
 _templates_dir = Path(__file__).parent / "templates"
+_execute_templates_dir = Path(__file__).parents[1] / "execute" / "templates"
 _env = Environment(  # noqa: S701 — templates are LLM prompts, not HTML; autoescape would break them
-    loader=FileSystemLoader(str(_templates_dir)), trim_blocks=True, lstrip_blocks=True
+    loader=ChoiceLoader([FileSystemLoader(str(_templates_dir)), FileSystemLoader(str(_execute_templates_dir))]),
+    trim_blocks=True,
+    lstrip_blocks=True,
 )
 
 
@@ -15,8 +25,16 @@ def render(template_name: str, **kwargs: Any) -> str:
     return _env.get_template(template_name).render(**kwargs)
 
 
-def render_fix_errors(*, errors: str, files: dict[str, str]) -> str:
-    return render("fix_errors.jinja2", errors=errors, files=files)
+def render_fix_errors(*, errors: str, files: dict[str, str], selected_packages: list[str] | None = None) -> str:
+    validated_packages = validate_optional_packages(selected_packages or [])
+    return render(
+        "fix_errors.jinja2",
+        errors=errors,
+        files=files,
+        allowed_imports=allowed_import_names(validated_packages),
+        package_fix_rules=_package_fix_rules(validated_packages),
+        package_unselected_fix_rules=_package_unselected_fix_rules(validated_packages),
+    )
 
 
 def render_fix_error_direct(
@@ -26,7 +44,9 @@ def render_fix_error_direct(
     error_line: int | None = None,
     error_stack: str | None = None,
     files: dict[str, str],
+    selected_packages: list[str] | None = None,
 ) -> str:
+    validated_packages = validate_optional_packages(selected_packages or [])
     return render(
         "fix_error_direct.jinja2",
         error_message=error_message,
@@ -34,4 +54,31 @@ def render_fix_error_direct(
         error_line=error_line,
         error_stack=error_stack,
         files=files,
+        allowed_imports=allowed_import_names(validated_packages),
+        package_fix_rules=_package_fix_rules(validated_packages),
+        package_unselected_fix_rules=_package_unselected_fix_rules(validated_packages),
     )
+
+
+def _package_fix_rules(selected_packages: list[str]) -> list[str]:
+    blocks: list[str] = []
+    for name in selected_packages:
+        package = OPTIONAL_PACKAGES[name]
+        try:
+            blocks.append(render(package.prompt_template(OptionalPackagePrompt.FIX_ERRORS_RULES)).strip())
+        except TemplateNotFound:
+            continue
+    return blocks
+
+
+def _package_unselected_fix_rules(selected_packages: list[str]) -> list[str]:
+    selected = set(selected_packages)
+    blocks: list[str] = []
+    for name, package in OPTIONAL_PACKAGES.items():
+        if name in selected:
+            continue
+        try:
+            blocks.append(render(package.prompt_template(OptionalPackagePrompt.FIX_ERRORS_UNSELECTED_RULES)).strip())
+        except TemplateNotFound:
+            continue
+    return blocks

--- a/backend/src/flow44/ai/agents/fix_error/templates/fix_error_direct.jinja2
+++ b/backend/src/flow44/ai/agents/fix_error/templates/fix_error_direct.jinja2
@@ -42,4 +42,21 @@ Rules:
 3. Do NOT refactor unrelated code
 4. Output complete file contents, not patches
 5. Do NOT include shell actions
-6. **CRITICAL**: Only use pre-installed packages (React, TypeScript, Vite, Tailwind CSS). Do NOT import other npm packages.
+
+{% include "_file_safety_rules.jinja2" %}
+
+{% include "_dependency_rules.jinja2" %}
+{% if package_fix_rules %}
+
+Package-specific repair rules:
+{% for rule_block in package_fix_rules %}
+{{ rule_block }}
+{% endfor %}
+{% endif %}
+{% if package_unselected_fix_rules %}
+
+Package-specific fallback repair rules:
+{% for rule_block in package_unselected_fix_rules %}
+{{ rule_block }}
+{% endfor %}
+{% endif %}

--- a/backend/src/flow44/ai/agents/fix_error/templates/fix_errors.jinja2
+++ b/backend/src/flow44/ai/agents/fix_error/templates/fix_errors.jinja2
@@ -30,3 +30,21 @@ Rules:
 2. Do NOT change functionality — only fix type errors.
 3. Output complete file contents, not patches.
 4. Do NOT include shell actions.
+
+{% include "_file_safety_rules.jinja2" %}
+
+{% include "_dependency_rules.jinja2" %}
+{% if package_fix_rules %}
+
+Package-specific repair rules:
+{% for rule_block in package_fix_rules %}
+{{ rule_block }}
+{% endfor %}
+{% endif %}
+{% if package_unselected_fix_rules %}
+
+Package-specific fallback repair rules:
+{% for rule_block in package_unselected_fix_rules %}
+{{ rule_block }}
+{% endfor %}
+{% endif %}

--- a/backend/src/flow44/ai/agents/followup/agent.py
+++ b/backend/src/flow44/ai/agents/followup/agent.py
@@ -8,10 +8,16 @@ from langfuse.decorators import langfuse_context, observe
 from pydantic import BaseModel
 
 from flow44.ai.agents._base import BaseAgent
+from flow44.ai.agents.execute.optional_packages import (
+    allowed_import_names,
+    package_install_names,
+    selected_packages_from_package_json,
+)
 from flow44.ai.agents.followup.prompts import render_followup
 from flow44.ai.core.messages import Message
 from flow44.ai.core.react_flow import ReActFlow
 from flow44.ai.core.tools import ToolExecutor, tool
+from flow44.ai.generated_app_contract import GeneratedAppContractError, assert_generated_code_contract
 from flow44.db.chat import get_messages
 from flow44.db.project import get_project
 from flow44.sandbox.main import PnpmSandbox
@@ -41,6 +47,7 @@ class FollowUpAgent(BaseAgent):
         self._diffs: list[FileDiff] = []
         self._files_changed: list[str] = []
         self._iteration = 0
+        self._selected_packages: list[str] = []
         self._executor = self._build_tool_executor()
 
     def _build_tool_executor(self) -> ToolExecutor:  # noqa: C901, PLR0915
@@ -110,6 +117,10 @@ class FollowUpAgent(BaseAgent):
             import difflib  # noqa: PLC0415
 
             try:
+                path = assert_generated_code_contract(path, content, allowed_import_names(self._selected_packages))
+            except GeneratedAppContractError as exc:
+                return f"Error: {exc}"
+            try:
                 old_content = await sandbox.read_file(path)
             except FileNotFoundError:
                 old_content = ""
@@ -139,6 +150,11 @@ class FollowUpAgent(BaseAgent):
             except FileNotFoundError:
                 return f"Error: File not found: {path}"
 
+            candidate = current.replace(search, replace, 1)
+            try:
+                path = assert_generated_code_contract(path, candidate, allowed_import_names(self._selected_packages))
+            except GeneratedAppContractError as exc:
+                return f"Error: {exc}"
             try:
                 await sandbox.edit_file(path, search, replace)
             except ValueError:
@@ -178,6 +194,7 @@ class FollowUpAgent(BaseAgent):
 
         await self.emit({"type": "phase", "phase": "exploring"})
         context = await self._build_context()
+        self._selected_packages = await self._prepare_optional_packages()
 
         # TODO: fix, after change to messages in db, we dont get internal chat history anymore.
         history = await get_messages(self.project_id)
@@ -190,6 +207,7 @@ class FollowUpAgent(BaseAgent):
         system_prompt = render_followup(
             project_summary=context["summary"],
             file_tree=context["file_tree"],
+            selected_packages=self._selected_packages,
         )
 
         react_flow: ReActFlow[BaseModel] = ReActFlow(name="followup", max_iterations=MAX_ITERATIONS)
@@ -263,6 +281,15 @@ class FollowUpAgent(BaseAgent):
                     }
                 )
             await self.emit({"type": "followup_step", **step_data})
+
+    async def _prepare_optional_packages(self) -> list[str]:
+        try:
+            package_json = await self.sandbox.read_file("package.json")
+        except (FileNotFoundError, PermissionError):
+            return []
+        selected_packages = selected_packages_from_package_json(package_json)
+        await self.sandbox.enable_optional_packages(package_install_names(selected_packages))
+        return selected_packages
 
     # TODO: feels like a general utils that should go out.
     def _format_file_tree(self, entries: list[Any], indent: int = 0) -> str:

--- a/backend/src/flow44/ai/agents/followup/prompts.py
+++ b/backend/src/flow44/ai/agents/followup/prompts.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import ChoiceLoader, Environment, FileSystemLoader
+
+from flow44.ai.agents.execute.optional_packages import allowed_import_names, validate_optional_packages
 
 _templates_dir = Path(__file__).parent / "templates"
+_execute_templates_dir = Path(__file__).parents[1] / "execute" / "templates"
 _env = Environment(  # noqa: S701 — templates are LLM prompts, not HTML; autoescape would break them
-    loader=FileSystemLoader(str(_templates_dir)), trim_blocks=True, lstrip_blocks=True
+    loader=ChoiceLoader([FileSystemLoader(str(_templates_dir)), FileSystemLoader(str(_execute_templates_dir))]),
+    trim_blocks=True,
+    lstrip_blocks=True,
 )
 
 
@@ -15,5 +20,11 @@ def render(template_name: str, **kwargs: Any) -> str:
     return _env.get_template(template_name).render(**kwargs)
 
 
-def render_followup(*, project_summary: str, file_tree: str) -> str:
-    return render("followup.jinja2", project_summary=project_summary, file_tree=file_tree)
+def render_followup(*, project_summary: str, file_tree: str, selected_packages: list[str] | None = None) -> str:
+    validated_packages = validate_optional_packages(selected_packages or [])
+    return render(
+        "followup.jinja2",
+        project_summary=project_summary,
+        file_tree=file_tree,
+        allowed_imports=allowed_import_names(validated_packages),
+    )

--- a/backend/src/flow44/ai/agents/followup/templates/followup.jinja2
+++ b/backend/src/flow44/ai/agents/followup/templates/followup.jinja2
@@ -24,3 +24,7 @@ Follow the EXPLORE → REASON → ACT pattern:
 - Keep changes minimal and focused on what the user asked for.
 - If the user asks a question, answer it in text. Only make edits if the user wants changes.
 - Do NOT include shell commands.
+
+{% include "_file_safety_rules.jinja2" %}
+
+{% include "_dependency_rules.jinja2" %}

--- a/backend/src/flow44/ai/agents/plan/templates/architecture.jinja2
+++ b/backend/src/flow44/ai/agents/plan/templates/architecture.jinja2
@@ -14,7 +14,7 @@ Given the user's request, design the technical architecture. Respond with ONLY a
     "src/types/index.ts"
   ],
   "state_management": "Description of state approach (useState, useReducer, context, etc.)",
-  "key_dependencies": "ONLY use these pre-installed packages: react, react-dom, @types/react, @types/react-dom, typescript, vite, tailwindcss, autoprefixer, postcss. Do NOT suggest adding other packages.",
+  "key_dependencies": "Use the template stack by default. Mention required capabilities, but do not invent package names; optional package selection is handled separately.",
   "notes": "Any important architectural decisions or trade-offs"
 }
 
@@ -25,7 +25,8 @@ Rules:
 - Keep it simple — prefer useState/useReducer over external state libraries unless complexity warrants it
 - All file paths are relative to the project root (e.g. src/App.tsx)
 - Include only the files that need to be created or modified
-- **CRITICAL**: ONLY use the pre-installed packages (react, react-dom, @types/react, @types/react-dom, typescript, vite, tailwindcss, autoprefixer, postcss). Do NOT suggest adding other packages or dependencies. All functionality must be implemented using built-in browser APIs and these pre-configured packages only.
+- Do not include `vite.config.ts`, `index.html`, `src/main.tsx`.
+- Do not invent npm packages. Optional packages may be used only when selected and installed by the package-selection step.
 {% if data_source_contexts %}
 
 The user's request includes the following data sources. Pre-built async API functions

--- a/backend/src/flow44/ai/generated_app_contract.py
+++ b/backend/src/flow44/ai/generated_app_contract.py
@@ -1,0 +1,121 @@
+"""Backend-enforced safety and dependency contract for AI-generated app files."""
+
+from __future__ import annotations
+
+import re
+from pathlib import PurePosixPath
+
+
+class GeneratedAppContractError(ValueError):
+    """Raised when generated output violates the app-generation contract."""
+
+
+_PROTECTED_FILES = {
+    "bun.lock",
+    "bun.lockb",
+    "composer.lock",
+    "index.html",
+    "npm-shrinkwrap.json",
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "uv.lock",
+    "yarn.lock",
+}
+_PROTECTED_SRC_PATHS = {
+    "src/config.ts",
+    "src/main.tsx",
+    "src/vite-env.d.ts",
+}
+_PROTECTED_SRC_DIRS = {
+    ("src", "api"),
+    ("src", "auth"),
+    ("src", "datasources"),
+    ("src", "platform"),
+}
+_PROTECTED_ROOT_DIRS = {
+    ".circleci",
+    ".github",
+    ".gitlab",
+    "backend",
+    "deployment",
+    "infrastructure",
+    "server",
+}
+_IMPORT_PATTERNS = (
+    re.compile(r"""(?:import|export)\s+(?:type\s+)?(?:[\s\S]*?\s+from\s+)?["']([^"']+)["']"""),
+    re.compile(r"""import\s*\(\s*["']([^"']+)["']\s*\)"""),
+    re.compile(r"""require\s*\(\s*["']([^"']+)["']\s*\)"""),
+    re.compile(r"""@import\s+(?:url\()?["']([^"']+)["']"""),
+)
+
+
+def normalize_generated_path(path: str) -> str:
+    """Normalize a generated path and reject absolute or traversal paths."""
+    if path.startswith(("/", "\\")):
+        raise GeneratedAppContractError(f"Unsafe generated file path: {path}")
+    normalized = path.replace("\\", "/").lstrip("/")
+    parts = PurePosixPath(normalized).parts
+    if not parts or any(part in {"", ".", ".."} for part in parts):
+        raise GeneratedAppContractError(f"Unsafe generated file path: {path}")
+    return str(PurePosixPath(*parts))
+
+
+def is_generated_app_file_allowed(path: str) -> bool:
+    """Return whether AI generation may edit a path."""
+    try:
+        normalized = normalize_generated_path(path)
+    except GeneratedAppContractError:
+        return False
+
+    parts = tuple(part.lower() for part in PurePosixPath(normalized).parts)
+    name = parts[-1].lower()
+    return not (
+        name in _PROTECTED_FILES
+        or normalized.lower() in _PROTECTED_SRC_PATHS
+        or name.startswith((".env", "vite.config."))
+        or parts[0] in _PROTECTED_ROOT_DIRS
+        or (len(parts) >= 2 and parts[:2] in _PROTECTED_SRC_DIRS)
+        or "template-guard" in name
+        or "template_guard" in name
+    )
+
+
+def assert_generated_app_file_allowed(path: str) -> str:
+    """Return a normalized path or raise for a protected target."""
+    normalized = normalize_generated_path(path)
+    if not is_generated_app_file_allowed(normalized):
+        raise GeneratedAppContractError(f"AI generation may not edit protected file: {normalized}")
+    return normalized
+
+
+def external_imports(content: str) -> set[str]:
+    """Extract external module specifiers from TypeScript/JavaScript source."""
+    imports: set[str] = set()
+    for pattern in _IMPORT_PATTERNS:
+        for match in pattern.finditer(content):
+            specifier = match.group(1)
+            if not specifier.startswith((".", "/")):
+                imports.add(specifier)
+    return imports
+
+
+def disallowed_external_imports(content: str, allowed_imports: list[str]) -> set[str]:
+    """Return external imports not covered by the explicit dependency contract."""
+    allowed = {"react", "react-dom", *allowed_imports}
+    return {
+        specifier
+        for specifier in external_imports(content)
+        if not any(specifier == package or specifier.startswith(f"{package}/") for package in allowed)
+    }
+
+
+def assert_generated_code_contract(path: str, content: str, allowed_imports: list[str]) -> str:
+    """Validate a generated file target and its external imports."""
+    normalized = assert_generated_app_file_allowed(path)
+    disallowed = sorted(disallowed_external_imports(content, allowed_imports))
+    if disallowed:
+        raise GeneratedAppContractError(
+            f"Generated file {normalized} imports unselected packages: {', '.join(disallowed)}"
+        )
+    return normalized

--- a/backend/src/flow44/sandbox/pnpm_mixin.py
+++ b/backend/src/flow44/sandbox/pnpm_mixin.py
@@ -1,5 +1,7 @@
+import json
 import logging
 import os
+import shlex
 import shutil
 from abc import ABC
 
@@ -20,6 +22,7 @@ class BuildCommandResult(BaseModel):
 class PnpmMixin(BaseSandbox, ABC):
     def configure_npmrc(self) -> None:
         npmrc = os.path.join(self.workspace_dir, ".npmrc")
+        # TODO: make this work for namespaced mode too
         store_path = "/.pnpm-store" if settings.SANDBOX_MODE == "namespaced" else settings.PNPM_STORE_DIR
 
         content = (
@@ -41,6 +44,31 @@ class PnpmMixin(BaseSandbox, ABC):
 
         async for line in self.exec("pnpm install 2>&1"):
             logger.info("[scaffold] %s", line.rstrip())
+
+    def _npm_package_declared(self, package_name: str) -> bool:
+        pkg_path = os.path.join(self.workspace_dir, "package.json")
+        if not os.path.isfile(pkg_path):
+            return False
+        with open(pkg_path, encoding="utf-8") as handle:
+            pkg = json.load(handle)
+        return package_name in pkg.get("dependencies", {})
+
+    def _npm_package_available(self, package_name: str) -> bool:
+        module_path = os.path.join(self.workspace_dir, "node_modules", *package_name.split("/"))
+        return self._npm_package_declared(package_name) and os.path.exists(module_path)
+
+    async def enable_optional_packages(self, package_names: list[str]) -> None:
+        """Install and verify all already-whitelisted optional packages."""
+        unique_names = list(dict.fromkeys(package_names))
+        missing = [name for name in unique_names if not self._npm_package_available(name)]
+        if missing:
+            command = "pnpm add " + " ".join(shlex.quote(name) for name in missing) + " 2>&1"
+            async for line in self.exec(command):
+                logger.info("[optional-packages] %s", line.rstrip())
+
+        unavailable = [name for name in unique_names if not self._npm_package_available(name)]
+        if unavailable:
+            raise RuntimeError(f"Optional package installation failed: {', '.join(unavailable)}")
 
     def _stamp_vite_config(self, template_dir: str) -> None:
         template_path = os.path.join(template_dir, "vite.config.ts")

--- a/backend/tests/ai/agents/execute/test_optional_packages.py
+++ b/backend/tests/ai/agents/execute/test_optional_packages.py
@@ -1,0 +1,133 @@
+"""Tests for optional package whitelist selection."""
+
+from __future__ import annotations
+
+from flow44.ai.agents.execute.optional_packages import (
+    OptionalPackageDecision,
+    allowed_import_names,
+    has_capability,
+    high_confidence_optional_package_decision,
+    package_capabilities,
+    package_install_names,
+    repair_unselected_package_references,
+    selected_package_names,
+    selected_packages_from_package_json,
+    validate_optional_package_decision,
+)
+
+CHART_DASHBOARD_PROMPT = "Build a dashboard with line charts and bar charts showing trends over time."
+
+
+def test_selected_package_names_accepts_whitelisted_dict_items() -> None:
+    decision = OptionalPackageDecision.model_validate(
+        {
+            "selected_packages": [
+                {"name": "mui", "capability": "material_ui_components", "reason": "Material UI requested"},
+                {"name": "recharts", "capability": "dashboard_charts", "reason": "dashboard charts"},
+                {"name": "made-up-package", "capability": "unknown", "reason": "not allowed"},
+            ]
+        }
+    )
+
+    assert selected_package_names(decision) == ["mui", "recharts"]
+    assert decision.selected_packages[0].capability == "material_ui_components"
+
+
+def test_selected_package_names_dedupes_declared_package_items() -> None:
+    decision = OptionalPackageDecision.model_validate(
+        {
+            "selected_packages": [
+                {"name": "mui", "reason": "Material UI requested"},
+                {"name": "mui", "reason": "duplicate"},
+            ]
+        }
+    )
+
+    assert selected_package_names(decision) == ["mui"]
+
+
+def test_validated_decision_preserves_first_valid_reason() -> None:
+    decision = OptionalPackageDecision.model_validate(
+        {
+            "selected_packages": [
+                {"name": "mui", "reason": "  Material UI requested  "},
+                {"name": "mui", "reason": "duplicate"},
+                {"name": "unknown", "reason": "invalid"},
+            ]
+        }
+    )
+
+    validated = validate_optional_package_decision(decision)
+
+    assert validated.model_dump() == {
+        "selected_packages": [
+            {"name": "mui", "capability": "material_ui_components", "reason": "Material UI requested"},
+        ]
+    }
+
+
+def test_optional_package_decision_defaults_missing_selection_to_empty() -> None:
+    decision = OptionalPackageDecision.model_validate({})
+
+    assert selected_package_names(decision) == []
+
+
+def test_selected_package_names_accepts_legacy_package_key() -> None:
+    decision = OptionalPackageDecision.model_validate(
+        {
+            "selected_packages": [
+                {"package": "mui"},
+            ]
+        }
+    )
+
+    assert selected_package_names(decision) == ["mui"]
+
+
+def test_package_capability_helpers() -> None:
+    selected = ["mui", "recharts"]
+
+    assert has_capability(selected, "material_ui_components")
+    assert has_capability(selected, "dashboard_charts")
+    assert package_capabilities(selected) == ["material_ui_components", "dashboard_charts"]
+    assert package_install_names(selected) == ["@mui/material", "@emotion/react", "@emotion/styled", "recharts"]
+
+
+def test_recovered_optional_package_mappings() -> None:
+    selected = ["recharts"]
+
+    assert package_capabilities(selected) == ["dashboard_charts"]
+    assert package_install_names(selected) == ["recharts"]
+    assert allowed_import_names(selected) == ["recharts"]
+
+
+def test_explicit_mui_prompt_selects_mui() -> None:
+    decision = high_confidence_optional_package_decision("Build this dashboard with Material UI.")
+    selected = selected_package_names(decision)
+
+    assert selected == ["mui"]
+
+
+def test_chart_dashboard_prompt_selects_recharts() -> None:
+    selected = selected_package_names(high_confidence_optional_package_decision(CHART_DASHBOARD_PROMPT))
+
+    assert selected == ["recharts"]
+
+
+def test_selected_packages_recovered_from_actual_dependency_names() -> None:
+    package_json = (
+        '{"dependencies":{"@mui/material":"latest","@emotion/react":"latest",'
+        '"@emotion/styled":"latest","recharts":"latest"}}'
+    )
+
+    assert selected_packages_from_package_json(package_json) == ["mui", "recharts"]
+
+
+def test_unselected_known_package_plan_reference_uses_fallback() -> None:
+    repaired = repair_unselected_package_references(
+        "Use mui for controls and recharts for dashboard charts.",
+        ["recharts"],
+    )
+
+    assert "mui" not in repaired
+    assert "recharts" in repaired

--- a/backend/tests/ai/agents/execute/test_package_contract_flow.py
+++ b/backend/tests/ai/agents/execute/test_package_contract_flow.py
@@ -1,0 +1,136 @@
+"""Regression tests for optional-package selection, installation, and planning order."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import flow44.ai.agents.execute.agent as execute_agent_module
+from flow44.ai.agents.execute.agent import ExecuteAgent
+from flow44.ai.agents.execute.execution_state import ExecutionState
+from flow44.ai.agents.execute.models import Task, WorkPlan
+from flow44.ai.agents.plan.models import ArchitectureDesign, UXDesign
+from flow44.ai.state import BuildState
+
+from .test_optional_packages import CHART_DASHBOARD_PROMPT
+
+
+class FakeSandbox:
+    project_id = "project"
+
+    def __init__(self) -> None:
+        self.install_calls: list[list[str]] = []
+
+    async def enable_optional_packages(self, package_names: list[str]) -> None:
+        self.install_calls.append(package_names)
+
+
+class FakeSpan:
+    id = "span"
+
+    def end(self) -> None:
+        pass
+
+
+class FakeLangfuse:
+    def span(self, **kwargs: Any) -> FakeSpan:
+        del kwargs
+        return FakeSpan()
+
+
+@pytest.mark.asyncio
+async def test_chart_package_is_installed_before_merge(monkeypatch: pytest.MonkeyPatch) -> None:
+    sandbox = FakeSandbox()
+    build_state = BuildState(project_id="project", user_content=CHART_DASHBOARD_PROMPT)
+    agent = ExecuteAgent("project", sandbox, build_state)  # type: ignore[arg-type]
+    calls: list[str] = []
+
+    async def fake_complete_chat(
+        messages: list[Any],
+        system_prompt: str,
+        model: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        del messages, model, metadata
+        if "## Allowed Optional Packages" in system_prompt:
+            calls.append("decision")
+            return '{"selected_packages":[]}'
+        assert sandbox.install_calls == [["recharts"]]
+        assert "`recharts` is selected" in system_prompt
+        assert "comparison, trend, composition, or distribution" in system_prompt
+        calls.append("merge")
+        return """
+        {
+          "summary": "Use recharts for dashboard trends",
+          "tasks": [
+            {
+              "id": "unsafe",
+              "title": "Edit Vite",
+              "description": "Change vite.config.ts",
+              "files": ["vite.config.ts"],
+              "depends_on": []
+            },
+            {
+              "id": "app",
+              "title": "Build app",
+              "description": "Use recharts for dashboard trends",
+              "files": ["src/App.tsx"],
+              "depends_on": ["unsafe"]
+            }
+          ]
+        }
+        """
+
+    monkeypatch.setattr(execute_agent_module, "complete_chat", fake_complete_chat)
+    state = ExecutionState(
+        build_state=build_state,
+        project_id="project",
+        sandbox_ref=sandbox,
+        llm_metadata_fn=lambda _: {},
+    )
+
+    plan = await agent._build_technical_plan(state)
+
+    assert calls == ["decision", "merge"]
+    assert plan.selected_packages == ["recharts"]
+    assert [task.files for task in plan.tasks] == [["src/App.tsx"]]
+    assert plan.tasks[0].depends_on == []
+    assert "recharts" in plan.tasks[0].description
+
+
+@pytest.mark.asyncio
+async def test_selected_packages_are_confirmed_before_codegen(monkeypatch: pytest.MonkeyPatch) -> None:
+    sandbox = FakeSandbox()
+    plan = WorkPlan(
+        id="plan",
+        summary="summary",
+        architecture=ArchitectureDesign(),
+        ux_design=UXDesign(),
+        tasks=[Task(id="app", title="App", description="", files=["src/App.tsx"])],
+        selected_packages=["mui", "recharts"],
+    )
+    build_state = BuildState(project_id="project", work_plan=plan)
+    agent = ExecuteAgent("project", sandbox, build_state)  # type: ignore[arg-type]
+    executed: list[str] = []
+
+    async def fake_execute_task(task: Task, state: ExecutionState) -> None:
+        del state
+        assert sandbox.install_calls == [["@mui/material", "@emotion/react", "@emotion/styled", "recharts"]]
+        executed.append(task.id)
+
+    async def emit(event: dict[str, Any]) -> None:
+        del event
+
+    monkeypatch.setattr(agent, "_execute_task", fake_execute_task)
+    state = ExecutionState(
+        build_state=build_state,
+        project_id="project",
+        sandbox_ref=sandbox,
+        emit_fn=emit,
+        langfuse_client=FakeLangfuse(),
+    )
+
+    await agent._step_execute_tasks(state)
+
+    assert executed == ["app"]

--- a/backend/tests/ai/test_generated_app_contract.py
+++ b/backend/tests/ai/test_generated_app_contract.py
@@ -1,0 +1,66 @@
+"""Tests for backend-enforced generated app file and import safety."""
+
+from __future__ import annotations
+
+import pytest
+
+from flow44.ai.generated_app_contract import (
+    GeneratedAppContractError,
+    assert_generated_code_contract,
+    disallowed_external_imports,
+    is_generated_app_file_allowed,
+)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "package.json",
+        "pnpm-lock.yaml",
+        "src/features/package.json",
+        "vite.config.ts",
+        "index.html",
+        ".env.local",
+        "src/main.tsx",
+        "src/vite-env.d.ts",
+        "src/platform/internal/README.md",
+        "backend/server.py",
+    ],
+)
+def test_protected_generated_app_files_are_rejected(path: str) -> None:
+    assert not is_generated_app_file_allowed(path)
+
+
+def test_normal_app_source_file_is_allowed() -> None:
+    assert is_generated_app_file_allowed("src/components/AssetMap.tsx")
+
+
+def test_unselected_external_import_is_rejected() -> None:
+    content = "import { Button } from '@mui/material';"
+
+    with pytest.raises(GeneratedAppContractError, match="@mui/material"):
+        assert_generated_code_contract("src/App.tsx", content, [])
+
+
+def test_selected_import_and_react_subpath_are_allowed() -> None:
+    content = """
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { Button } from '@mui/material';
+import { helper } from './helper';
+"""
+
+    assert disallowed_external_imports(content, ["@mui/material"]) == set()
+    assert assert_generated_code_contract("src/App.tsx", content, ["@mui/material"]) == "src/App.tsx"
+
+
+def test_dynamic_unselected_import_is_rejected() -> None:
+    assert disallowed_external_imports("const dialog = import('@mui/material/Dialog');", []) == {
+        "@mui/material/Dialog"
+    }
+
+
+def test_css_package_import_is_rejected() -> None:
+    assert disallowed_external_imports("@import 'unselected-theme/styles.css';", []) == {
+        "unselected-theme/styles.css"
+    }

--- a/backend/tests/ai/test_prompts.py
+++ b/backend/tests/ai/test_prompts.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from flow44.ai.agents.execute.prompts import render_codegen, render_merge, render_summary
+from flow44.ai.agents.execute.prompts import (
+    render_codegen,
+    render_fix_errors,
+    render_merge,
+    render_package_decision,
+    render_summary,
+)
+from flow44.ai.agents.fix_error.prompts import render_fix_error_direct
 from flow44.ai.agents.followup.prompts import render_followup
 from flow44.ai.agents.plan.prompts import render_architecture, render_user_plan
 
@@ -43,6 +50,7 @@ class TestPromptRendering:
         assert "following data sources" in result
         assert "dataSourceSalesData" in result
         assert "Pre-generated file" in result
+        assert "**Parameters:**" in result
 
     def test_architecture_without_data_sources(self) -> None:
         result = render_architecture(data_source_contexts=None)
@@ -51,6 +59,7 @@ class TestPromptRendering:
     def test_merge_without_data_sources(self) -> None:
         result = render_merge(has_data_sources=False)
         assert "Pre-Generated Files" not in result
+        assert result.count("## File Safety Rules") == 1
 
     def test_merge_with_data_sources(self) -> None:
         result = render_merge(has_data_sources=True)
@@ -74,10 +83,14 @@ class TestPromptRendering:
         result = render_followup(
             project_summary="A todo app built with React",
             file_tree="src/\n  App.tsx\n  Todo.tsx",
+            selected_packages=["mui"],
         )
         assert "todo app" in result
         assert "App.tsx" in result
         assert "EXPLORE" in result
+        assert result.count("## Dependency Rules") == 1
+        assert result.count("## File Safety Rules") == 1
+        assert "- @mui/material" in result
 
     def test_codegen(self) -> None:
         result = render_codegen(
@@ -90,6 +103,28 @@ class TestPromptRendering:
         assert "Create Header" in result
         assert "src/Header.tsx" in result
         assert "flowArtifact" in result
+        assert result.count("## Dependency Rules") == 1
+        assert result.count("## File Safety Rules") == 1
+        assert "Single-page app only" not in result
+
+    def test_codegen_allows_only_selected_packages(self) -> None:
+        result = render_codegen(
+            task_title="Build dashboard charts",
+            task_description="Build dashboard charts",
+            task_files=["src/App.tsx"],
+            architecture={},
+            ux_design={},
+            selected_packages=["mui", "recharts", "unknown-package"],
+        )
+
+        dependency_rules = result.split("## Dependency Rules", 1)[1].split("## Selected Package Rules", 1)[0]
+        assert result.count("## Dependency Rules") == 1
+        assert result.count("## Selected Package Rules") == 1
+        assert "- @mui/material" in dependency_rules
+        assert "- @emotion/react" in dependency_rules
+        assert "- @emotion/styled" in dependency_rules
+        assert "- recharts" in dependency_rules
+        assert "unknown-package" not in result
 
     def test_codegen_with_dependencies(self) -> None:
         result = render_codegen(
@@ -137,3 +172,52 @@ class TestPromptRendering:
         assert "Analytics" in result
         assert "dataSourceAnalytics" in result
         assert "pre-generated" in result.lower()
+        assert "**Parameters:**" in result
+
+    def test_package_decision_allows_multiple_packages(self) -> None:
+        result = render_package_decision()
+
+        assert "Select zero, one, or multiple packages" in result
+        assert "Use more than one package" in result
+        assert '"name":"package-name"' in result
+        assert '"reason":"short reason based on the user request"' in result
+        assert '"capability"' not in result
+
+    def test_codegen_package_variants_are_strict_and_phase_specific(self) -> None:
+        variants = {
+            "none": [],
+            "mui": ["mui"],
+            "charts": ["recharts"],
+            "both": ["mui", "recharts"],
+        }
+
+        for name, selected in variants.items():
+            result = render_codegen(
+                task_title=name,
+                task_description=name,
+                task_files=["src/App.tsx"],
+                architecture={},
+                ux_design={},
+                selected_packages=selected,
+            )
+            dependency_rules = result.split("## Dependency Rules", 1)[1].split("## Selected Package Rules", 1)[0]
+
+            assert result.count("## Dependency Rules") == 1
+            assert result.count("## File Safety Rules") == 1
+            assert "`vite.config.ts`" in result
+            assert "`index.html`" in result
+            assert "`src/platform/*`" in result
+            assert ("- @mui/material" in dependency_rules) == ("mui" in selected)
+            assert ("- recharts" in dependency_rules) == ("recharts" in selected)
+            assert ("Import Material UI components" in result) == ("mui" in selected)
+            assert ("Use Recharts components" in result) == ("recharts" in selected)
+
+    def test_fix_prompts_include_file_safety_rules_once(self) -> None:
+        execute_fix = render_fix_errors(errors="broken", files={"src/App.tsx": "broken"})
+        direct_fix = render_fix_error_direct(error_message="broken", files={"src/App.tsx": "broken"})
+
+        assert execute_fix.count("## File Safety Rules") == 1
+        assert direct_fix.count("## File Safety Rules") == 1
+        assert execute_fix.count("## Dependency Rules") == 1
+        assert direct_fix.count("## Dependency Rules") == 1
+        assert "Only use pre-installed packages" not in direct_fix

--- a/backend/tests/sandbox/test_optional_packages.py
+++ b/backend/tests/sandbox/test_optional_packages.py
@@ -1,0 +1,48 @@
+"""Tests for optional npm package installation verification."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_enable_optional_packages_installs_all_and_verifies(sandbox, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    (tmp_path / "package.json").write_text('{"dependencies":{}}', encoding="utf-8")
+    commands: list[str] = []
+
+    async def fake_exec(command: str) -> AsyncIterator[str]:
+        commands.append(command)
+        dependencies = {
+            "@mui/material": "latest",
+            "@emotion/react": "latest",
+            "@emotion/styled": "latest",
+            "recharts": "latest",
+        }
+        (tmp_path / "package.json").write_text(json.dumps({"dependencies": dependencies}), encoding="utf-8")
+        for package in dependencies:
+            (tmp_path / "node_modules" / package).mkdir(parents=True, exist_ok=True)
+        yield "installed"
+
+    sandbox.exec = fake_exec
+
+    await sandbox.enable_optional_packages(["@mui/material", "@emotion/react", "@emotion/styled", "recharts"])
+
+    assert commands == ["pnpm add @mui/material @emotion/react @emotion/styled recharts 2>&1"]
+
+
+@pytest.mark.asyncio
+async def test_enable_optional_packages_fails_when_package_is_unavailable(sandbox, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    (tmp_path / "package.json").write_text('{"dependencies":{}}', encoding="utf-8")
+
+    async def fake_exec(command: str) -> AsyncIterator[str]:
+        del command
+        yield "failed"
+
+    sandbox.exec = fake_exec
+
+    with pytest.raises(RuntimeError, match="@mui/material"):
+        await sandbox.enable_optional_packages(["@mui/material"])


### PR DESCRIPTION
## Summary
- add a whitelist-driven optional package selection and installation flow
- support MUI and Recharts for generated apps
- enforce generated-file and dependency contracts across execute, fix-error, and follow-up flows
- add package-specific planning, code generation, and repair prompt templates

## Stack
- depends on #135
- excludes React Router, maps, tables, ReGraph, preview routing, and shared publishing

## Validation
- `git diff --cached --check`
- focused optional-package tests: 46 passed
- Ruff checks passed