### PR TITLE
PR 3: Add generated app routing and shared publishing

### DIFF
--- a/backend/pnpm-project-template/src/platform/react-router-dom/README.md
+++ b/backend/pnpm-project-template/src/platform/react-router-dom/README.md
@@ -1,0 +1,9 @@
+# react-router-dom Platform Contract
+
+Generated apps may use this folder only when `react-router-dom` is selected.
+
+- Import `getRouterBasename` from `./platform/react-router-dom/routerBasename`.
+- Wrap routes in `App.tsx` with `<BrowserRouter basename={getRouterBasename()}>`.
+- Keep `BrowserRouter` out of `main.tsx`.
+- Use `Link`, `NavLink`, or `useNavigate()` for internal routes; never use `<a href="/...">`.
+- Do not edit `vite.config.ts`, `index.html`, env files, or files under `src/platform/`.

--- a/backend/pnpm-project-template/src/platform/react-router-dom/routerBasename.ts
+++ b/backend/pnpm-project-template/src/platform/react-router-dom/routerBasename.ts
@@ -1,0 +1,10 @@
+// PLATFORM SYSTEM FILE.
+// Required for preview/export/publish base-path support when react-router-dom is selected.
+// Do not remove or rewrite during normal app generation.
+
+/** Basename for react-router-dom, derived from Vite `base` via import.meta.env.BASE_URL. */
+export function getRouterBasename(): string {
+  const base = import.meta.env.BASE_URL || '/';
+  const normalized = base.replace(/\/+$/, '');
+  return normalized || '/';
+}

--- a/backend/pnpm-project-template/src/vite-env.d.ts
+++ b/backend/pnpm-project-template/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_BASE_PATH: string;
+  readonly VITE_API_BASE: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/backend/pnpm-project-template/vite.config.ts
+++ b/backend/pnpm-project-template/vite.config.ts
@@ -3,9 +3,10 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
+  const base = env.VITE_BASE_PATH || env.VITE_BASE || '/'
   return {
     plugins: [react()],
-    base: env.VITE_BASE ?? '/api/preview/{{PROJECT_ID}}/proxy/',
+    base,
     define: {
       'import.meta.env.VITE_AUTH_PROVIDER_URL': JSON.stringify('{{AUTH_PROVIDER_URL}}'),
       'import.meta.env.VITE_AUTH_STORAGE_KEY': JSON.stringify('{{AUTH_STORAGE_KEY}}'),

--- a/backend/src/flow44/ai/agents/execute/agent.py
+++ b/backend/src/flow44/ai/agents/execute/agent.py
@@ -33,8 +33,8 @@ from flow44.ai.core.messages import Message
 from flow44.ai.core.provider import complete_chat, stream_chat
 from flow44.ai.generated_app_contract import (
     GeneratedAppContractError,
-    validate_generated_app_edit_path,
     validate_generated_app_file_contract,
+    validate_generated_app_path_allowed,
 )
 from flow44.ai.helpers import parse_json_response
 from flow44.ai.parser import ActionParser
@@ -312,7 +312,7 @@ class ExecuteAgent(BaseAgent):
             safe_files: list[str] = []
             for path in task_data.get("files", []):
                 try:
-                    safe_files.append(validate_generated_app_edit_path(path))
+                    safe_files.append(validate_generated_app_path_allowed(path))
                 except GeneratedAppContractError:
                     logger.warning("[execute] Dropping protected file from generated plan: %s", path)
             if not safe_files:
@@ -415,7 +415,7 @@ class ExecuteAgent(BaseAgent):
                 parser.feed(chunk)
             parser.flush()
 
-            expected_paths = {validate_generated_app_edit_path(path) for path in task.files}
+            expected_paths = {validate_generated_app_path_allowed(path) for path in task.files}
             allowed_imports = allowed_import_names(state.build_state.work_plan.selected_packages)
             validated: list[tuple[str, str]] = []
             for path, content in generated:

--- a/backend/src/flow44/ai/agents/execute/prompts.py
+++ b/backend/src/flow44/ai/agents/execute/prompts.py
@@ -14,15 +14,15 @@ from flow44.ai.agents.optional_packages import (
     optional_package_prompt_context,
     validate_optional_packages,
 )
+from flow44.ai.agents.template_paths import TEMPLATE_PROMPTS_PATH
 from flow44.ai.generated_app_contract import (
     GeneratedAppPathSafetyPromptContext,
     generated_app_path_safety_prompt_context,
 )
 
 _templates_dir = Path(__file__).parent / "templates"
-_shared_templates_dir = Path(__file__).parents[1] / "templates"
 _env = Environment(  # noqa: S701 — templates are LLM prompts, not HTML; autoescape would break them
-    loader=ChoiceLoader([FileSystemLoader(str(_templates_dir)), FileSystemLoader(str(_shared_templates_dir))]),
+    loader=ChoiceLoader([FileSystemLoader(str(_templates_dir)), FileSystemLoader(str(TEMPLATE_PROMPTS_PATH))]),
     trim_blocks=True,
     lstrip_blocks=True,
 )

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/codegen_context.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/codegen_context.jinja2
@@ -1,0 +1,4 @@
+## Router Contract
+
+The app may be served under a nested preview/shared base path. Vite handles asset URLs; React Router
+needs the runtime basename from `src/platform/react-router-dom/routerBasename.ts` for app routes.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/codegen_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/codegen_rules.jinja2
@@ -1,0 +1,15 @@
+Required:
+- Use `BrowserRouter` with `basename={getRouterBasename()}`.
+- Import `getRouterBasename` from the platform router helper.
+- Use `Routes` and `Route` for route definitions.
+- Use `Link`, `NavLink`, or `useNavigate` for internal navigation.
+
+Forbidden:
+- Do not hardcode router basename.
+- Do not use raw `<a href="/...">` for internal app routes.
+- Do not edit `vite.config.ts`.
+- Do not edit `index.html`.
+- Do not edit env files.
+- Do not edit `src/platform/*`.
+- Do not add or remove Vite `base`.
+- Do not add `<base href>`.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/codegen_unselected_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/codegen_unselected_rules.jinja2
@@ -1,0 +1,1 @@
+If route-based navigation is needed but no routing package is selected, use simple state-based page-like views instead of client-side routes. Do not add router setup or routing imports unless a routing package is selected.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/fix_errors_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/fix_errors_rules.jinja2
@@ -1,0 +1,5 @@
+Routing rules:
+- Fix routing code in normal app source files only.
+- Keep `<BrowserRouter basename={getRouterBasename()}>` in `App.tsx`; do not use `HashRouter`.
+- In-app navigation must use `Link`, `NavLink`, or `useNavigate`; never `<a href="/...">` for app routes.
+- Do not edit `vite.config.ts`, `index.html`, env files, or `src/platform/*`.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/fix_errors_unselected_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/fix_errors_unselected_rules.jinja2
@@ -1,0 +1,1 @@
+If route-based navigation is needed but no routing package is selected, use simple state-based page-like views instead of client-side routes. Do not add router setup or routing imports unless a routing package is selected.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/merge_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/merge_rules.jinja2
@@ -1,0 +1,1 @@
+- `react-router-dom` is selected: create page tasks under `src/pages/*` and a final `src/App.tsx` task that wires the routes.

--- a/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/merge_unselected_rules.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/optional_packages/react-router-dom/merge_unselected_rules.jinja2
@@ -1,0 +1,1 @@
+If route-based navigation is needed but no routing package is selected, plan simple state-based page-like views instead of client-side routes. Do not plan router setup or routing imports unless a routing package is selected.

--- a/backend/src/flow44/ai/agents/fix_error/prompts.py
+++ b/backend/src/flow44/ai/agents/fix_error/prompts.py
@@ -11,15 +11,15 @@ from flow44.ai.agents.optional_packages import (
     allowed_import_names,
     validate_optional_packages,
 )
+from flow44.ai.agents.template_paths import TEMPLATE_PROMPTS_PATH
 from flow44.ai.generated_app_contract import (
     GeneratedAppPathSafetyPromptContext,
     generated_app_path_safety_prompt_context,
 )
 
 _templates_dir = Path(__file__).parent / "templates"
-_shared_templates_dir = Path(__file__).parents[1] / "templates"
 _env = Environment(  # noqa: S701 — templates are LLM prompts, not HTML; autoescape would break them
-    loader=ChoiceLoader([FileSystemLoader(str(_templates_dir)), FileSystemLoader(str(_shared_templates_dir))]),
+    loader=ChoiceLoader([FileSystemLoader(str(_templates_dir)), FileSystemLoader(str(TEMPLATE_PROMPTS_PATH))]),
     trim_blocks=True,
     lstrip_blocks=True,
 )

--- a/backend/src/flow44/ai/agents/followup/agent.py
+++ b/backend/src/flow44/ai/agents/followup/agent.py
@@ -28,6 +28,13 @@ MAX_ITERATIONS = 15
 MAX_READ_LINES = 1000
 
 
+def _format_generated_app_contract_error(exc: GeneratedAppContractError) -> str:
+    return (
+        f"Generated app contract violation: {exc}\n"
+        "Pick an editable app source file and only import packages selected for this project."
+    )
+
+
 @dataclass
 class FileDiff:
     path: str
@@ -123,7 +130,7 @@ class FollowUpAgent(BaseAgent):
                     path, content, allowed_import_names(self._selected_packages)
                 )
             except GeneratedAppContractError as exc:
-                return f"Error: {exc}"
+                return _format_generated_app_contract_error(exc)
             try:
                 old_content = await sandbox.read_file(path)
             except FileNotFoundError:
@@ -160,7 +167,7 @@ class FollowUpAgent(BaseAgent):
                     path, candidate, allowed_import_names(self._selected_packages)
                 )
             except GeneratedAppContractError as exc:
-                return f"Error: {exc}"
+                return _format_generated_app_contract_error(exc)
             try:
                 await sandbox.edit_file(path, search, replace)
             except ValueError:

--- a/backend/src/flow44/ai/agents/followup/prompts.py
+++ b/backend/src/flow44/ai/agents/followup/prompts.py
@@ -6,15 +6,15 @@ from typing import Literal
 from jinja2 import ChoiceLoader, Environment, FileSystemLoader
 
 from flow44.ai.agents.optional_packages import allowed_import_names, validate_optional_packages
+from flow44.ai.agents.template_paths import TEMPLATE_PROMPTS_PATH
 from flow44.ai.generated_app_contract import (
     GeneratedAppPathSafetyPromptContext,
     generated_app_path_safety_prompt_context,
 )
 
 _templates_dir = Path(__file__).parent / "templates"
-_shared_templates_dir = Path(__file__).parents[1] / "templates"
 _env = Environment(  # noqa: S701 — templates are LLM prompts, not HTML; autoescape would break them
-    loader=ChoiceLoader([FileSystemLoader(str(_templates_dir)), FileSystemLoader(str(_shared_templates_dir))]),
+    loader=ChoiceLoader([FileSystemLoader(str(_templates_dir)), FileSystemLoader(str(TEMPLATE_PROMPTS_PATH))]),
     trim_blocks=True,
     lstrip_blocks=True,
 )

--- a/backend/src/flow44/ai/agents/optional_packages.py
+++ b/backend/src/flow44/ai/agents/optional_packages.py
@@ -38,6 +38,20 @@ class OptionalPackage:
 
 
 OPTIONAL_PACKAGES: dict[str, OptionalPackage] = {
+    "react-router-dom": OptionalPackage(
+        name="react-router-dom",
+        capability="client_routing",
+        packages=("react-router-dom",),
+        use_when=(
+            "Use when the user asks for multiple real screens/pages, route URLs, deep links, nested routes, "
+            "or browser back/forward behavior."
+        ),
+        avoid_when=(
+            "Avoid for one-screen apps, simple tabs, accordions, same-page sections, or local conditional "
+            "panels that do not need URLs."
+        ),
+        strong_intent_groups=(("deep link",), ("browser back",), ("route url",)),
+    ),
     "mui": OptionalPackage(
         name="mui",
         capability="material_ui_components",

--- a/backend/src/flow44/ai/agents/plan/prompts.py
+++ b/backend/src/flow44/ai/agents/plan/prompts.py
@@ -6,15 +6,15 @@ from typing import Any, Literal, overload
 
 from jinja2 import ChoiceLoader, Environment, FileSystemLoader
 
+from flow44.ai.agents.template_paths import TEMPLATE_PROMPTS_PATH
 from flow44.ai.generated_app_contract import (
     GeneratedAppPathSafetyPromptContext,
     generated_app_path_safety_prompt_context,
 )
 
 _templates_dir = Path(__file__).parent / "templates"
-_shared_templates_dir = Path(__file__).parents[1] / "templates"
 _env = Environment(  # noqa: S701 — templates are LLM prompts, not HTML; autoescape would break them
-    loader=ChoiceLoader([FileSystemLoader(str(_templates_dir)), FileSystemLoader(str(_shared_templates_dir))]),
+    loader=ChoiceLoader([FileSystemLoader(str(_templates_dir)), FileSystemLoader(str(TEMPLATE_PROMPTS_PATH))]),
     trim_blocks=True,
     lstrip_blocks=True,
 )

--- a/backend/src/flow44/ai/agents/template_paths.py
+++ b/backend/src/flow44/ai/agents/template_paths.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+TEMPLATE_PROMPTS_PATH = Path(__file__).parent / "templates"

--- a/backend/src/flow44/ai/agents/templates/_file_safety_rules.jinja2
+++ b/backend/src/flow44/ai/agents/templates/_file_safety_rules.jinja2
@@ -16,9 +16,6 @@ Do not touch:
 {% for path in file_safety.protected_src_dirs -%}
 - `{{ path }}`
 {% endfor -%}
-{% for path in file_safety.protected_root_dirs -%}
-- `{{ path }}`
-{% endfor -%}
 {% for pattern in file_safety.protected_name_patterns -%}
 - files matching `{{ pattern }}`
 {% endfor %}

--- a/backend/src/flow44/ai/generated_app_contract.py
+++ b/backend/src/flow44/ai/generated_app_contract.py
@@ -6,13 +6,7 @@ import re
 from pathlib import PurePosixPath
 from typing import TypedDict
 
-from flow44.ai.generated_app_file_rules import (
-    PROTECTED_FILES,
-    PROTECTED_NAME_PREFIXES,
-    PROTECTED_NAME_SUBSTRINGS,
-    PROTECTED_SRC_DIRS,
-    PROTECTED_SRC_PATHS,
-)
+from flow44.ai.generated_app_file_rules import PROTECTED_APP_FILE_RULES
 
 
 class GeneratedAppContractError(ValueError):
@@ -36,12 +30,13 @@ _IMPORT_PATTERNS = (
 
 def generated_app_path_safety_prompt_context() -> GeneratedAppPathSafetyPromptContext:
     """Return protected path rules for prompt templates from the backend contract."""
+    rules = PROTECTED_APP_FILE_RULES
     return {
-        "protected_files": sorted(PROTECTED_FILES),
-        "protected_src_paths": sorted(PROTECTED_SRC_PATHS),
-        "protected_src_dirs": sorted(f"{'/'.join(path)}/*" for path in PROTECTED_SRC_DIRS),
-        "protected_name_patterns": [f"{prefix}*" for prefix in PROTECTED_NAME_PREFIXES]
-        + [f"*{substring}*" for substring in PROTECTED_NAME_SUBSTRINGS],
+        "protected_files": sorted(rules.files),
+        "protected_src_paths": sorted(rules.src_paths),
+        "protected_src_dirs": sorted(f"{'/'.join(path)}/*" for path in rules.src_dirs),
+        "protected_name_patterns": [f"{prefix}*" for prefix in rules.name_prefixes]
+        + [f"*{substring}*" for substring in rules.name_substrings],
     }
 
 
@@ -63,14 +58,21 @@ def is_generated_app_path_allowed(path: str) -> bool:
     except GeneratedAppContractError:
         return False
 
-    parts = tuple(part.lower() for part in PurePosixPath(normalized).parts)
-    name = parts[-1].lower()
-    return not (
-        name in PROTECTED_FILES
-        or normalized.lower() in PROTECTED_SRC_PATHS
-        or name.startswith(PROTECTED_NAME_PREFIXES)
-        or (len(parts) >= 2 and parts[:2] in PROTECTED_SRC_DIRS)
-        or any(substring in name for substring in PROTECTED_NAME_SUBSTRINGS)
+    return not _is_protected_generated_app_path(normalized)
+
+
+def _is_protected_generated_app_path(normalized_path: str) -> bool:
+    rules = PROTECTED_APP_FILE_RULES
+    normalized = normalized_path.lower()
+    parts = PurePosixPath(normalized).parts
+    name = parts[-1]
+
+    return (
+        name in rules.files
+        or normalized in rules.src_paths
+        or name.startswith(rules.name_prefixes)
+        or (len(parts) >= 2 and parts[:2] in rules.src_dirs)
+        or any(substring in name for substring in rules.name_substrings)
     )
 
 

--- a/backend/src/flow44/ai/generated_app_contract.py
+++ b/backend/src/flow44/ai/generated_app_contract.py
@@ -10,7 +10,6 @@ from flow44.ai.generated_app_file_rules import (
     PROTECTED_FILES,
     PROTECTED_NAME_PREFIXES,
     PROTECTED_NAME_SUBSTRINGS,
-    PROTECTED_ROOT_DIRS,
     PROTECTED_SRC_DIRS,
     PROTECTED_SRC_PATHS,
 )
@@ -42,7 +41,6 @@ def generated_app_path_safety_prompt_context() -> GeneratedAppPathSafetyPromptCo
         "protected_files": sorted(PROTECTED_FILES),
         "protected_src_paths": sorted(PROTECTED_SRC_PATHS),
         "protected_src_dirs": sorted(f"{'/'.join(path)}/*" for path in PROTECTED_SRC_DIRS),
-        "protected_root_dirs": sorted(f"{path}/*" for path in PROTECTED_ROOT_DIRS),
         "protected_name_patterns": [f"{prefix}*" for prefix in PROTECTED_NAME_PREFIXES]
         + [f"*{substring}*" for substring in PROTECTED_NAME_SUBSTRINGS],
     }
@@ -72,7 +70,6 @@ def is_generated_app_path_allowed(path: str) -> bool:
         name in PROTECTED_FILES
         or normalized.lower() in PROTECTED_SRC_PATHS
         or name.startswith(PROTECTED_NAME_PREFIXES)
-        or parts[0] in PROTECTED_ROOT_DIRS
         or (len(parts) >= 2 and parts[:2] in PROTECTED_SRC_DIRS)
         or any(substring in name for substring in PROTECTED_NAME_SUBSTRINGS)
     )

--- a/backend/src/flow44/ai/generated_app_contract.py
+++ b/backend/src/flow44/ai/generated_app_contract.py
@@ -23,7 +23,6 @@ class GeneratedAppPathSafetyPromptContext(TypedDict):
     protected_files: list[str]
     protected_src_paths: list[str]
     protected_src_dirs: list[str]
-    protected_root_dirs: list[str]
     protected_name_patterns: list[str]
 
 

--- a/backend/src/flow44/ai/generated_app_contract.py
+++ b/backend/src/flow44/ai/generated_app_contract.py
@@ -76,7 +76,7 @@ def _is_protected_generated_app_path(normalized_path: str) -> bool:
     )
 
 
-def validate_generated_app_edit_path(path: str) -> str:
+def validate_generated_app_path_allowed(path: str) -> str:
     """Return a normalized path or raise for a protected target."""
     normalized = normalize_generated_app_path(path)
     if not is_generated_app_path_allowed(normalized):
@@ -107,7 +107,7 @@ def find_disallowed_external_imports(content: str, allowed_imports: list[str]) -
 
 def validate_generated_app_file_contract(path: str, content: str, allowed_imports: list[str]) -> str:
     """Validate a generated file target and its external imports."""
-    normalized = validate_generated_app_edit_path(path)
+    normalized = validate_generated_app_path_allowed(path)
     disallowed = sorted(find_disallowed_external_imports(content, allowed_imports))
     if disallowed:
         raise GeneratedAppContractError(

--- a/backend/src/flow44/ai/generated_app_file_rules.py
+++ b/backend/src/flow44/ai/generated_app_file_rules.py
@@ -2,24 +2,43 @@
 
 from __future__ import annotations
 
-PROTECTED_FILES = {
-    "index.html",
-    "package.json",
-    "package-lock.json",
-    "pnpm-lock.yaml",
-    "uv.lock",
-    "yarn.lock",
-}
-PROTECTED_SRC_PATHS = {
-    "src/config.ts",
-    "src/main.tsx",
-    "src/vite-env.d.ts",
-}
-PROTECTED_SRC_DIRS = {
-    ("src", "api"),
-    ("src", "auth"),
-    ("src", "datasources"),
-    ("src", "platform"),
-}
-PROTECTED_NAME_PREFIXES = (".env", "vite.config.")
-PROTECTED_NAME_SUBSTRINGS = ("template-guard", "template_guard")
+from typing import NamedTuple
+
+
+class ProtectedAppFileRules(NamedTuple):
+    files: frozenset[str]
+    src_paths: frozenset[str]
+    src_dirs: frozenset[tuple[str, ...]]
+    name_prefixes: tuple[str, ...]
+    name_substrings: tuple[str, ...]
+
+
+PROTECTED_APP_FILE_RULES = ProtectedAppFileRules(
+    files=frozenset(
+        {
+            "index.html",
+            "package.json",
+            "package-lock.json",
+            "pnpm-lock.yaml",
+            "uv.lock",
+            "yarn.lock",
+        }
+    ),
+    src_paths=frozenset(
+        {
+            "src/config.ts",
+            "src/main.tsx",
+            "src/vite-env.d.ts",
+        }
+    ),
+    src_dirs=frozenset(
+        {
+            ("src", "api"),
+            ("src", "auth"),
+            ("src", "datasources"),
+            ("src", "platform"),
+        }
+    ),
+    name_prefixes=(".env", "vite.config."),
+    name_substrings=("template-guard", "template_guard"),
+)

--- a/backend/src/flow44/ai/generated_app_file_rules.py
+++ b/backend/src/flow44/ai/generated_app_file_rules.py
@@ -21,10 +21,5 @@ PROTECTED_SRC_DIRS = {
     ("src", "datasources"),
     ("src", "platform"),
 }
-PROTECTED_ROOT_DIRS = {
-    ".github",
-    ".gitlab",
-    "backend",
-}
 PROTECTED_NAME_PREFIXES = (".env", "vite.config.")
 PROTECTED_NAME_SUBSTRINGS = ("template-guard", "template_guard")

--- a/backend/src/flow44/api/publish.py
+++ b/backend/src/flow44/api/publish.py
@@ -10,8 +10,9 @@ from sqlalchemy.exc import IntegrityError
 from flow44.api.deps import Permission, ProjectDep, require_permission
 from flow44.config import settings
 from flow44.db.project import is_handle_taken, update_project_published_url
-from flow44.integrations.s3 import deploy_single_html
-from flow44.sandbox.operations import BuildError, build_single_html
+from flow44.integrations.s3 import deploy_shared_dist
+from flow44.paths import shared_base_path
+from flow44.sandbox.operations import BuildError, build_dist
 
 logger = logging.getLogger(__name__)
 
@@ -76,24 +77,24 @@ async def publish_to_s3(
     if slug:
         await _validate_slug(slug, project.id)
 
-    # Build a single HTML string containing the entire app with inline assets
+    handle = slug or project.id
+
+    # Keep assets and lazy-loaded route chunks available under the public app URL.
     try:
-        html_content = await build_single_html(project.id)
+        dist_dir = await build_dist(project.id, public_base=shared_base_path(handle))
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except BuildError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    # Deploy the single HTML to S3 securely without blocking the event loop
     try:
         loop = asyncio.get_running_loop()
         # TODO - REFACTOR TO AIOBOTO3: boto3 doesn't support async so we have to run in a thread pool.
-        await loop.run_in_executor(None, deploy_single_html, html_content, project.id)
+        await loop.run_in_executor(None, deploy_shared_dist, dist_dir, project.id)
     except Exception as exc:
         logger.exception("S3 deployment failed for project %s", project.id)
         raise HTTPException(status_code=502, detail=f"S3 deployment failed: {exc}") from exc
 
-    handle = slug or project.id
     try:
         await update_project_published_url(project.id, handle)
     except IntegrityError as exc:

--- a/backend/src/flow44/api/shared.py
+++ b/backend/src/flow44/api/shared.py
@@ -1,46 +1,84 @@
-"""Public serving routes: published apps by project ID or custom slug."""
+"""Public serving routes for shared apps by project ID or custom slug."""
 
 import logging
+import mimetypes
+import os
 
 import httpx
 from fastapi import APIRouter, HTTPException
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, Response
 
 from flow44.config import settings
 from flow44.db.project import get_project_by_handle
-from flow44.integrations.s3 import get_published_url
+from flow44.integrations.s3 import get_published_url, get_shared_asset_url
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/shared", tags=["shared"])
 
 
-def _s3_response(html: str, headers_src: httpx.Headers) -> HTMLResponse:
+def _cache_headers(headers_src: httpx.Headers) -> dict[str, str]:
     headers: dict[str, str] = {"Cache-Control": f"public, max-age={settings.S3_CACHE_TTL}, must-revalidate"}
     if "etag" in headers_src:
         headers["ETag"] = headers_src["etag"]
     if "last-modified" in headers_src:
         headers["Last-Modified"] = headers_src["last-modified"]
-    return HTMLResponse(content=html, headers=headers)
+    return headers
 
 
-async def _proxy_from_s3(source_url: str, log_ctx: str) -> HTMLResponse:
+async def _fetch_first(urls: list[str], log_ctx: str) -> httpx.Response:
     async with httpx.AsyncClient() as client:
-        try:
-            resp = await client.get(source_url, timeout=15.0)
-            resp.raise_for_status()
-            return _s3_response(resp.text, resp.headers)
-        except Exception:
-            logger.exception("Failed to fetch published app for %s from %s", log_ctx, source_url)
-            raise HTTPException(status_code=502, detail="Error fetching published app from S3.") from None
+        for source_url in urls:
+            try:
+                resp = await client.get(source_url, timeout=15.0)
+                resp.raise_for_status()
+                return resp
+            except Exception:
+                logger.debug("Failed shared object fetch for %s from %s", log_ctx, source_url, exc_info=True)
+    raise HTTPException(status_code=502, detail="Error fetching shared app from S3.")
+
+
+def _is_static_asset(path: str) -> bool:
+    return bool(os.path.splitext(path)[1])
+
+
+async def _serve_shared_path(handle: str, path: str) -> Response:
+    project = await get_project_by_handle(handle)
+    if not project or not project.published_at:
+        raise HTTPException(status_code=404, detail=f"No shared app found for handle '{handle}'.")
+
+    requested_path = path.lstrip("/") or "index.html"
+    urls = [get_shared_asset_url(project.id, requested_path)]
+    if requested_path == "index.html":
+        urls.append(get_published_url(project.id))
+
+    try:
+        resp = await _fetch_first(urls, f"handle {handle}, path {requested_path}")
+    except HTTPException:
+        if _is_static_asset(requested_path):
+            raise
+        resp = await _fetch_first(
+            [get_shared_asset_url(project.id, "index.html"), get_published_url(project.id)],
+            f"handle {handle}, SPA fallback",
+        )
+
+    headers = _cache_headers(resp.headers)
+    if requested_path == "index.html" or not _is_static_asset(requested_path):
+        return HTMLResponse(content=resp.text, headers=headers)
+    media_type = resp.headers.get("content-type") or mimetypes.guess_type(requested_path)[0]
+    return Response(content=resp.content, headers=headers, media_type=media_type)
 
 
 @router.get("/{handle}", response_class=HTMLResponse)
-async def serve_published_app(handle: str) -> HTMLResponse:
-    """Serve a published app via its custom slug or project ID handle."""
-    project = await get_project_by_handle(handle)
-    if not project or not project.published_at:
-        raise HTTPException(status_code=404, detail=f"No published app found for handle '{handle}'.")
+async def serve_shared_app(handle: str) -> HTMLResponse:
+    """Serve a shared app via its custom slug or project ID handle."""
+    response = await _serve_shared_path(handle, "index.html")
+    if not isinstance(response, HTMLResponse):
+        raise HTTPException(status_code=502, detail="Shared index is not HTML.")
+    return response
 
-    source_url = get_published_url(project.id)
-    return await _proxy_from_s3(source_url, f"handle {handle}")
+
+@router.get("/{handle}/{path:path}")
+async def serve_shared_asset_or_route(handle: str, path: str) -> Response:
+    """Serve a shared asset, or index.html for a client-side route."""
+    return await _serve_shared_path(handle, path)

--- a/backend/src/flow44/integrations/s3.py
+++ b/backend/src/flow44/integrations/s3.py
@@ -1,6 +1,8 @@
 import functools
 import json
 import logging
+import mimetypes
+import os
 from typing import Any
 
 import boto3
@@ -55,8 +57,14 @@ def _get_s3_key(project_id: str) -> str:
 
 
 def get_published_url(project_id: str) -> str:
-    """Return the internal S3 URL for a published project."""
+    """Return the legacy single-HTML URL for a published project."""
     key = _get_s3_key(project_id)
+    return f"{settings.S3_ENDPOINT_URL}/{settings.S3_BUCKET_NAME}/{key}"
+
+
+def get_shared_asset_url(project_id: str, relative_path: str) -> str:
+    # Legacy storage prefix kept for backward compatibility.
+    key = f"published/{project_id}/{relative_path.lstrip('/')}"
     return f"{settings.S3_ENDPOINT_URL}/{settings.S3_BUCKET_NAME}/{key}"
 
 
@@ -72,3 +80,23 @@ def deploy_single_html(html_content: str, project_id: str) -> str:
         StorageClass=settings.S3_STORAGE_CLASS,
     )
     return get_published_url(project_id)
+
+
+def deploy_shared_dist(dist_dir: str, project_id: str) -> str:
+    """Upload a Vite dist directory for shared serving."""
+    s3 = connect_to_s3()
+    for root, _, files in os.walk(dist_dir):
+        for filename in files:
+            absolute_path = os.path.join(root, filename)
+            relative_path = os.path.relpath(absolute_path, dist_dir).replace(os.sep, "/")
+            with open(absolute_path, "rb") as handle:
+                s3.put_object(
+                    Bucket=settings.S3_BUCKET_NAME,
+                    # Legacy storage prefix kept for backward compatibility.
+                    Key=f"published/{project_id}/{relative_path}",
+                    Body=handle.read(),
+                    ContentType=mimetypes.guess_type(filename)[0] or "application/octet-stream",
+                    ACL="public-read",
+                    StorageClass=settings.S3_STORAGE_CLASS,
+                )
+    return get_shared_asset_url(project_id, "index.html")

--- a/backend/src/flow44/paths.py
+++ b/backend/src/flow44/paths.py
@@ -1,0 +1,34 @@
+"""Public base paths used by generated apps."""
+
+from __future__ import annotations
+
+import re
+
+PREVIEW_API_PREFIX = "/api/preview"
+SHARED_PREFIX = "/shared"
+
+_PUBLIC_BASE_PREFIX = re.compile(r"^(?:api/preview/[^/]+/proxy|shared/[^/]+)/")
+
+
+def preview_base_path(project_id: str) -> str:
+    return f"{PREVIEW_API_PREFIX}/{project_id}/proxy/"
+
+
+def shared_base_path(handle: str) -> str:
+    return f"{SHARED_PREFIX}/{handle}/"
+
+
+def sandbox_path_env(*, public_base: str, api_base_url: str) -> dict[str, str]:
+    """Vite env vars for preview/export/publish builds."""
+    return {
+        # VITE_BASE keeps existing workspaces compatible; VITE_BASE_PATH is the
+        # clearer name used by the current template.
+        "VITE_BASE": public_base,
+        "VITE_BASE_PATH": public_base,
+        "VITE_API_BASE": api_base_url,
+    }
+
+
+def strip_public_base_prefix(href: str) -> str:
+    """Map a generated public asset URL back to a dist-relative path."""
+    return _PUBLIC_BASE_PREFIX.sub("", href.lstrip("/\\"))

--- a/backend/src/flow44/sandbox/operations.py
+++ b/backend/src/flow44/sandbox/operations.py
@@ -9,6 +9,7 @@ import re
 from langfuse.decorators import observe
 
 from flow44.config import settings
+from flow44.paths import sandbox_path_env, strip_public_base_prefix
 from flow44.sandbox.manager import sandbox_manager
 
 logger = logging.getLogger(__name__)
@@ -73,7 +74,7 @@ def _inline_js_assets(html: str, dist_dir: str) -> str:
 
 
 def _resolve_asset_path(dist_dir: str, href: str) -> str | None:
-    cleaned = href.lstrip("/\\")
+    cleaned = strip_public_base_prefix(href)
     candidate = os.path.join(dist_dir, cleaned)
     try:
         if os.path.commonpath([os.path.realpath(dist_dir), os.path.realpath(candidate)]) != os.path.realpath(dist_dir):
@@ -88,9 +89,10 @@ def _inline_favicon(html: str, dist_dir: str, workspace_dir: str) -> str:
 
     def replace_favicon(match: re.Match[str]) -> str:
         href = match.group(1)
+        cleaned_href = strip_public_base_prefix(href)
         # Try dist first, then workspace root (dev favicons live in public/)
         for base in (dist_dir, os.path.join(workspace_dir, "public"), workspace_dir):
-            path = os.path.join(base, href.lstrip("/\\"))
+            path = os.path.join(base, cleaned_href)
             if os.path.isfile(path):
                 try:
                     with open(path, "rb") as f:
@@ -114,19 +116,17 @@ def _inline_favicon(html: str, dist_dir: str, workspace_dir: str) -> str:
     )
 
 
-@observe(name="build-single-html")  # type: ignore[untyped-decorator]
-async def build_single_html(project_id: str) -> str:
-    """Build the project and return a single self-contained HTML string."""
+async def build_dist(project_id: str, *, public_base: str = "/") -> str:
+    """Build the project and return its dist directory."""
     sandbox = await sandbox_manager.get_sandbox(project_id)
 
     workspace_dir = sandbox.workspace_dir
 
-    # Write a temporary .env.production.local so vite picks up overrides
-    api_base = settings.EXPORT_API_BASE_URL
     env_file = os.path.join(workspace_dir, ".env.production.local")
     try:
+        env_vars = sandbox_path_env(public_base=public_base, api_base_url=settings.EXPORT_API_BASE_URL)
         with open(env_file, "w", encoding="utf-8") as f:  # noqa: ASYNC230
-            f.write(f"VITE_BASE=/\nVITE_API_BASE={api_base}\n")
+            f.write("\n".join(f"{key}={value}" for key, value in env_vars.items()) + "\n")
 
         build_output_lines: list[str] = []
         async for line in sandbox.exec("pnpm build"):
@@ -143,6 +143,17 @@ async def build_single_html(project_id: str) -> str:
 
     if not os.path.isfile(index_path):  # noqa: ASYNC240
         raise BuildError(f"Build failed or dist/index.html not found.\n\n{build_output}")
+
+    return dist_dir
+
+
+@observe(name="build-single-html")  # type: ignore[untyped-decorator]
+async def build_single_html(project_id: str) -> str:
+    """Build the project and return a single self-contained HTML string."""
+    dist_dir = await build_dist(project_id)
+    sandbox = await sandbox_manager.get_sandbox(project_id)
+    workspace_dir = sandbox.workspace_dir
+    index_path = os.path.join(dist_dir, "index.html")
 
     with open(index_path, encoding="utf-8", errors="replace") as f:  # noqa: ASYNC230
         html = f.read()

--- a/backend/src/flow44/sandbox/pnpm_mixin.py
+++ b/backend/src/flow44/sandbox/pnpm_mixin.py
@@ -8,6 +8,7 @@ from abc import ABC
 from pydantic import BaseModel
 
 from flow44.config import settings
+from flow44.paths import preview_base_path, sandbox_path_env
 from flow44.sandbox.base import BaseSandbox
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,7 @@ class PnpmMixin(BaseSandbox, ABC):
         shutil.copytree(template_dir, self.workspace_dir, dirs_exist_ok=True)
 
         self._stamp_vite_config(template_dir)
+        self._configure_preview_paths()
         self.configure_npmrc()
 
         async for line in self.exec("pnpm install 2>&1"):
@@ -142,12 +144,28 @@ class PnpmMixin(BaseSandbox, ABC):
     async def start_dev_server(self) -> None:
         await self.stop_background_process("dev-server")
 
+        self._configure_preview_paths()
         env = os.environ.copy()
+        env.update(
+            sandbox_path_env(
+                public_base=preview_base_path(self.project_id),
+                api_base_url=settings.EXPORT_API_BASE_URL,
+            )
+        )
         env["FORCE_COLOR"] = "1"
 
         cmd = f"pnpm dev --port {self.port} --strictPort --host 0.0.0.0"
         await self._spawn_background("dev-server", cmd, env)
         logger.info("Dev server started for %s on port %d", self.project_id, self.port)
+
+    def _configure_preview_paths(self) -> None:
+        env_path = os.path.join(self.workspace_dir, ".env.local")
+        env_vars = sandbox_path_env(
+            public_base=preview_base_path(self.project_id),
+            api_base_url=settings.EXPORT_API_BASE_URL,
+        )
+        with open(env_path, "w", encoding="utf-8") as handle:
+            handle.write("\n".join(f"{key}={value}" for key, value in env_vars.items()) + "\n")
 
     async def stop_dev_server(self) -> None:
         await self.stop_background_process("dev-server")

--- a/backend/tests/ai/agents/test_followup_contract_errors.py
+++ b/backend/tests/ai/agents/test_followup_contract_errors.py
@@ -1,0 +1,12 @@
+from flow44.ai.agents.followup.agent import _format_generated_app_contract_error
+from flow44.ai.generated_app_contract import GeneratedAppContractError
+
+
+def test_followup_contract_error_includes_specific_violation_and_recovery_guidance() -> None:
+    message = _format_generated_app_contract_error(
+        GeneratedAppContractError("AI generation may not edit protected file: src/main.tsx")
+    )
+
+    assert message.startswith("Generated app contract violation: ")
+    assert "AI generation may not edit protected file: src/main.tsx" in message
+    assert "Pick an editable app source file" in message

--- a/backend/tests/ai/agents/test_optional_packages.py
+++ b/backend/tests/ai/agents/test_optional_packages.py
@@ -108,6 +108,12 @@ def test_explicit_mui_prompt_selects_mui() -> None:
     assert selected == ["mui"]
 
 
+def test_deep_link_prompt_selects_react_router() -> None:
+    decision = high_confidence_optional_package_decision("Add a deep link to the project details page.")
+
+    assert selected_package_names(decision) == ["react-router-dom"]
+
+
 def test_chart_dashboard_prompt_selects_recharts() -> None:
     selected = selected_package_names(high_confidence_optional_package_decision(CHART_DASHBOARD_PROMPT))
 

--- a/backend/tests/ai/test_generated_app_contract.py
+++ b/backend/tests/ai/test_generated_app_contract.py
@@ -9,8 +9,8 @@ from flow44.ai.generated_app_contract import (
     find_disallowed_external_imports,
     generated_app_path_safety_prompt_context,
     is_generated_app_path_allowed,
-    validate_generated_app_edit_path,
     validate_generated_app_file_contract,
+    validate_generated_app_path_allowed,
 )
 
 
@@ -46,11 +46,11 @@ def test_unselected_external_import_is_rejected() -> None:
 @pytest.mark.parametrize("path", ["/src/App.tsx", "../src/App.tsx", "src/../App.tsx"])
 def test_unsafe_generated_paths_are_rejected(path: str) -> None:
     with pytest.raises(GeneratedAppContractError):
-        validate_generated_app_edit_path(path)
+        validate_generated_app_path_allowed(path)
 
 
 def test_generated_path_is_normalized() -> None:
-    assert validate_generated_app_edit_path("src\\components\\AssetMap.tsx") == "src/components/AssetMap.tsx"
+    assert validate_generated_app_path_allowed("src\\components\\AssetMap.tsx") == "src/components/AssetMap.tsx"
 
 
 def test_file_safety_prompt_context_uses_contract_values() -> None:

--- a/backend/tests/ai/test_generated_app_contract.py
+++ b/backend/tests/ai/test_generated_app_contract.py
@@ -26,7 +26,6 @@ from flow44.ai.generated_app_contract import (
         "src/main.tsx",
         "src/vite-env.d.ts",
         "src/platform/internal/README.md",
-        "backend/server.py",
     ],
 )
 def test_protected_generated_app_files_are_rejected(path: str) -> None:
@@ -60,7 +59,6 @@ def test_file_safety_prompt_context_uses_contract_values() -> None:
     assert "package.json" in context["protected_files"]
     assert "src/main.tsx" in context["protected_src_paths"]
     assert "src/platform/*" in context["protected_src_dirs"]
-    assert "backend/*" in context["protected_root_dirs"]
     assert "vite.config.*" in context["protected_name_patterns"]
 
 

--- a/backend/tests/ai/test_prompts.py
+++ b/backend/tests/ai/test_prompts.py
@@ -192,9 +192,10 @@ class TestPromptRendering:
     def test_codegen_package_variants_are_strict_and_phase_specific(self) -> None:
         variants = {
             "none": [],
+            "router": ["react-router-dom"],
             "mui": ["mui"],
             "charts": ["recharts"],
-            "both": ["mui", "recharts"],
+            "all": ["react-router-dom", "mui", "recharts"],
         }
 
         for name, selected in variants.items():
@@ -215,6 +216,8 @@ class TestPromptRendering:
             assert "`src/platform/*`" in result
             assert ("- @mui/material" in dependency_rules) == ("mui" in selected)
             assert ("- recharts" in dependency_rules) == ("recharts" in selected)
+            assert ("- react-router-dom" in dependency_rules) == ("react-router-dom" in selected)
+            assert ("basename={getRouterBasename()}" in result) == ("react-router-dom" in selected)
             assert ("Import Material UI components" in result) == ("mui" in selected)
             assert ("Use Recharts components" in result) == ("recharts" in selected)
 

--- a/backend/tests/api/test_export.py
+++ b/backend/tests/api/test_export.py
@@ -131,51 +131,97 @@ async def test_export_html_error():
 
 
 @pytest.mark.asyncio
-async def test_proxy_published_app_basic():
+async def test_proxy_shared_app_basic():
     project_id = "published-proj"
     mock_project = AsyncMock()
     mock_project.id = project_id
     mock_project.published_url = project_id
     mock_project.published_at = "2026-04-18T21:00:00Z"
 
-    with patch("flow44.api.shared.get_project_by_handle", return_value=mock_project):
-        with patch("flow44.api.shared.get_published_url", return_value="https://s3.local/published.html"):
-            with patch("httpx.AsyncClient.get") as mock_get:
-                mock_resp = AsyncMock()
-                mock_resp.status_code = 200
-                mock_resp.text = "<html>S3 Content</html>"
-                mock_resp.headers = {"etag": "tag123"}
-                mock_resp.raise_for_status = lambda: None
-                mock_get.return_value = mock_resp
+    with (
+        patch("flow44.api.shared.get_project_by_handle", return_value=mock_project),
+        patch("flow44.api.shared.get_published_url", return_value="https://s3.local/published.html"),
+        patch("httpx.AsyncClient.get") as mock_get,
+    ):
+        mock_resp = AsyncMock()
+        mock_resp.status_code = 200
+        mock_resp.text = "<html>S3 Content</html>"
+        mock_resp.headers = {"etag": "tag123"}
+        mock_resp.raise_for_status = lambda: None
+        mock_get.return_value = mock_resp
 
-                response = client.get(f"/shared/{project_id}")
+        response = client.get(f"/shared/{project_id}")
 
-                assert response.status_code == 200
-                assert response.text == "<html>S3 Content</html>"
-                assert response.headers["ETag"] == "tag123"
-                assert response.headers["Cache-Control"] == f"public, max-age={settings.S3_CACHE_TTL}, must-revalidate"
+        assert response.status_code == 200
+        assert response.text == "<html>S3 Content</html>"
+        assert response.headers["ETag"] == "tag123"
+        assert response.headers["Cache-Control"] == f"public, max-age={settings.S3_CACHE_TTL}, must-revalidate"
 
 
 @pytest.mark.asyncio
-async def test_proxy_published_app_fetch_error():
+async def test_proxy_shared_app_fetch_error():
     project_id = "fetch-err"
     mock_project = AsyncMock()
     mock_project.id = project_id
     mock_project.published_url = project_id
     mock_project.published_at = "2026-04-18T21:00:00Z"
 
-    with patch("flow44.api.shared.get_project_by_handle", return_value=mock_project):
-        with patch("flow44.api.shared.get_published_url", return_value="https://s3.local/published.html"):
-            with patch("httpx.AsyncClient.get", side_effect=Exception("S3 Down")):
-                response = client.get(f"/shared/{project_id}")
-                assert response.status_code == 502
-                assert response.json()["detail"] == "Error fetching published app from S3."
+    with (
+        patch("flow44.api.shared.get_project_by_handle", return_value=mock_project),
+        patch("flow44.api.shared.get_published_url", return_value="https://s3.local/published.html"),
+        patch("httpx.AsyncClient.get", side_effect=Exception("S3 Down")),
+    ):
+        response = client.get(f"/shared/{project_id}")
+        assert response.status_code == 502
+        assert response.json()["detail"] == "Error fetching shared app from S3."
 
 
 @pytest.mark.asyncio
-async def test_proxy_published_app_not_found():
+async def test_proxy_shared_app_not_found():
     project_id = "non-existent"
     with patch("flow44.api.shared.get_project_by_handle", return_value=None):
         response = client.get(f"/shared/{project_id}")
         assert response.status_code == 404
-        assert response.json()["detail"] == f"No published app found for handle '{project_id}'."
+        assert response.json()["detail"] == f"No shared app found for handle '{project_id}'."
+
+
+@pytest.mark.asyncio
+async def test_proxy_shared_asset():
+    project = AsyncMock(id="published-proj", published_at="2026-04-18T21:00:00Z")
+    with patch("flow44.api.shared.get_project_by_handle", return_value=project), patch(
+        "httpx.AsyncClient.get"
+    ) as mock_get:
+        response_from_s3 = AsyncMock()
+        response_from_s3.content = b"console.log('ok')"
+        response_from_s3.headers = {"content-type": "application/javascript"}
+        response_from_s3.raise_for_status = lambda: None
+        mock_get.return_value = response_from_s3
+
+        response = client.get("/shared/my-app/assets/main.js")
+
+    assert response.status_code == 200
+    assert response.content == b"console.log('ok')"
+
+
+@pytest.mark.asyncio
+async def test_proxy_shared_spa_route_falls_back_to_index():
+    project = AsyncMock(id="published-proj", published_at="2026-04-18T21:00:00Z")
+    index_response = AsyncMock()
+    index_response.text = "<html>app</html>"
+    index_response.headers = {}
+    index_response.raise_for_status = lambda: None
+
+    async def get_object(url: str, **_: object):
+        if url.endswith("/reports/daily"):
+            raise FileNotFoundError("missing route object")
+        if url.endswith("/index.html"):
+            return index_response
+        raise AssertionError(url)
+
+    with patch("flow44.api.shared.get_project_by_handle", return_value=project), patch(
+        "httpx.AsyncClient.get", side_effect=get_object
+    ):
+        response = client.get("/shared/my-app/reports/daily")
+
+    assert response.status_code == 200
+    assert response.text == "<html>app</html>"

--- a/backend/tests/api/test_publish_slug.py
+++ b/backend/tests/api/test_publish_slug.py
@@ -68,8 +68,8 @@ class TestPublish:
 
     def _patch_build_and_deploy(self):
         return (
-            patch("flow44.api.publish.build_single_html", return_value="<html>ok</html>"),
-            patch("flow44.api.publish.deploy_single_html", return_value=MOCK_S3_URL),
+            patch("flow44.api.publish.build_dist", return_value="dist"),
+            patch("flow44.api.publish.deploy_shared_dist", return_value=MOCK_S3_URL),
             patch.object(settings, "S3_BUCKET_NAME", "test-bucket"),
         )
 
@@ -77,7 +77,7 @@ class TestPublish:
     async def test_publish_with_slug(self):
         p_build, p_deploy, p_bucket = self._patch_build_and_deploy()
         with (
-            p_build,
+            p_build as mock_build,
             p_deploy,
             p_bucket,
             patch("flow44.api.publish.is_handle_taken", return_value=False),
@@ -92,6 +92,7 @@ class TestPublish:
             assert data["url"] == "/shared/my-cool-app"
             assert data["handle"] == "my-cool-app"
             mock_update.assert_awaited_once_with("proj-1", "my-cool-app")
+            mock_build.assert_awaited_once_with("proj-1", public_base="/shared/my-cool-app/")
 
     @pytest.mark.asyncio
     async def test_publish_without_slug(self):
@@ -189,33 +190,35 @@ class TestShareBySlug:
     async def test_share_returns_proxied_html(self):
         mock_proj = _mock_project(published_url="my-app", published_at="2026-04-18T21:00:00Z")
         mock_proj.id = "proj-123"
-        with patch("flow44.api.shared.get_project_by_handle", return_value=mock_proj):
-            with patch("flow44.api.shared.get_published_url", return_value="https://s3.local/proj-123.html"), \
-                 patch("httpx.AsyncClient.get") as mock_get:
-                mock_resp = AsyncMock()
-                mock_resp.status_code = 200
-                mock_resp.text = "<html>Shared App</html>"
-                mock_resp.headers = {
-                    "etag": '"abc"',
-                    "last-modified": "Thu, 10 Apr 2026 12:00:00 GMT",
-                }
-                mock_resp.raise_for_status = lambda: None
-                mock_get.return_value = mock_resp
+        with (
+            patch("flow44.api.shared.get_project_by_handle", return_value=mock_proj),
+            patch("flow44.api.shared.get_published_url", return_value="https://s3.local/proj-123.html"),
+            patch("httpx.AsyncClient.get") as mock_get,
+        ):
+            mock_resp = AsyncMock()
+            mock_resp.status_code = 200
+            mock_resp.text = "<html>Shared App</html>"
+            mock_resp.headers = {
+                "etag": '"abc"',
+                "last-modified": "Thu, 10 Apr 2026 12:00:00 GMT",
+            }
+            mock_resp.raise_for_status = lambda: None
+            mock_get.return_value = mock_resp
 
-                response = client.get("/shared/my-app")
+            response = client.get("/shared/my-app")
 
-                assert response.status_code == 200
-                assert response.text == "<html>Shared App</html>"
-                assert response.headers["Cache-Control"] == f"public, max-age={settings.S3_CACHE_TTL}, must-revalidate"
-                assert response.headers["ETag"] == '"abc"'
-                assert response.headers["Last-Modified"] == "Thu, 10 Apr 2026 12:00:00 GMT"
+            assert response.status_code == 200
+            assert response.text == "<html>Shared App</html>"
+            assert response.headers["Cache-Control"] == f"public, max-age={settings.S3_CACHE_TTL}, must-revalidate"
+            assert response.headers["ETag"] == '"abc"'
+            assert response.headers["Last-Modified"] == "Thu, 10 Apr 2026 12:00:00 GMT"
 
     @pytest.mark.asyncio
     async def test_share_unknown_slug_returns_404(self):
         with patch("flow44.api.shared.get_project_by_handle", return_value=None):
             response = client.get("/shared/nonexistent")
             assert response.status_code == 404
-            assert "No published app found" in response.json()["detail"]
+            assert "No shared app found" in response.json()["detail"]
 
     @pytest.mark.asyncio
     async def test_share_route_is_public(self):
@@ -228,20 +231,22 @@ class TestShareBySlug:
         mock_proj.id = "proj-123"
         saved = app.dependency_overrides.pop(validate_token, None)
         try:
-            with patch("flow44.api.shared.get_project_by_handle", return_value=mock_proj):
-                with patch("flow44.api.shared.get_published_url", return_value="https://s3.local/proj-123.html"), \
-                     patch("httpx.AsyncClient.get") as mock_get:
-                    mock_resp = AsyncMock()
-                    mock_resp.status_code = 200
-                    mock_resp.text = "<html>Shared App</html>"
-                    mock_resp.headers = {}
-                    mock_resp.raise_for_status = lambda: None
-                    mock_get.return_value = mock_resp
+            with (
+                patch("flow44.api.shared.get_project_by_handle", return_value=mock_proj),
+                patch("flow44.api.shared.get_published_url", return_value="https://s3.local/proj-123.html"),
+                patch("httpx.AsyncClient.get") as mock_get,
+            ):
+                mock_resp = AsyncMock()
+                mock_resp.status_code = 200
+                mock_resp.text = "<html>Shared App</html>"
+                mock_resp.headers = {}
+                mock_resp.raise_for_status = lambda: None
+                mock_get.return_value = mock_resp
 
-                    response = client.get("/shared/my-app")
+                response = client.get("/shared/my-app")
 
-                    assert response.status_code == 200
-                    assert response.text == "<html>Shared App</html>"
+                assert response.status_code == 200
+                assert response.text == "<html>Shared App</html>"
         finally:
             if saved is not None:
                 app.dependency_overrides[validate_token] = saved
@@ -250,9 +255,11 @@ class TestShareBySlug:
     async def test_share_s3_failure_returns_502(self):
         mock_proj = _mock_project(published_url="my-app", published_at="2026-04-18T21:00:00Z")
         mock_proj.id = "proj-123"
-        with patch("flow44.api.shared.get_project_by_handle", return_value=mock_proj):
-            with patch("flow44.api.shared.get_published_url", return_value="https://s3.local/proj-123.html"), \
-                 patch("httpx.AsyncClient.get", side_effect=Exception("S3 down")):
-                response = client.get("/shared/my-app")
-                assert response.status_code == 502
-                assert "Error fetching published app" in response.json()["detail"]
+        with (
+            patch("flow44.api.shared.get_project_by_handle", return_value=mock_proj),
+            patch("flow44.api.shared.get_published_url", return_value="https://s3.local/proj-123.html"),
+            patch("httpx.AsyncClient.get", side_effect=Exception("S3 down")),
+        ):
+            response = client.get("/shared/my-app")
+            assert response.status_code == 502
+            assert "Error fetching shared app" in response.json()["detail"]

--- a/backend/tests/integrations/test_s3_integration.py
+++ b/backend/tests/integrations/test_s3_integration.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from flow44.config import settings
-from flow44.integrations.s3 import connect_to_s3, deploy_single_html, setup_bucket
+from flow44.integrations.s3 import connect_to_s3, deploy_shared_dist, deploy_single_html, setup_bucket
 
 
 @pytest.fixture(autouse=True)
@@ -49,17 +49,36 @@ def test_deploy_single_html():
         project_id = "proj-123"
 
         # Ensure settings are controlled
-        with patch.object(settings, "S3_BUCKET_NAME", "my-bucket"):
-            with patch.object(settings, "S3_ENDPOINT_URL", "http://s3.local"):
-                url = deploy_single_html(html_content, project_id)
+        with (
+            patch.object(settings, "S3_BUCKET_NAME", "my-bucket"),
+            patch.object(settings, "S3_ENDPOINT_URL", "http://s3.local"),
+        ):
+            url = deploy_single_html(html_content, project_id)
 
-                expected_key = f"published/{project_id}.html"
-                mock_client.put_object.assert_called_once_with(
-                    Bucket="my-bucket",
-                    Key=expected_key,
-                    Body=html_content.encode("utf-8"),
-                    ContentType="text/html",
-                    ACL="public-read",
-                    StorageClass=settings.S3_STORAGE_CLASS,
-                )
-                assert url == f"http://s3.local/my-bucket/{expected_key}"
+            expected_key = f"published/{project_id}.html"
+            mock_client.put_object.assert_called_once_with(
+                Bucket="my-bucket",
+                Key=expected_key,
+                Body=html_content.encode("utf-8"),
+                ContentType="text/html",
+                ACL="public-read",
+                StorageClass=settings.S3_STORAGE_CLASS,
+            )
+            assert url == f"http://s3.local/my-bucket/{expected_key}"
+
+
+def test_deploy_shared_dist(tmp_path):
+    dist = tmp_path / "dist"
+    (dist / "assets").mkdir(parents=True)
+    (dist / "index.html").write_text("<html>index</html>")
+    (dist / "assets" / "main.js").write_text("console.log('ok')")
+
+    with patch("flow44.integrations.s3.connect_to_s3") as mock_connect:
+        mock_connect.return_value = MagicMock()
+        with patch.object(settings, "S3_BUCKET_NAME", "my-bucket"), patch.object(
+            settings, "S3_ENDPOINT_URL", "http://s3.local"
+        ):
+            url = deploy_shared_dist(str(dist), "proj-456")
+
+    assert mock_connect.return_value.put_object.call_count == 2
+    assert url == "http://s3.local/my-bucket/published/proj-456/index.html"

--- a/backend/tests/sandbox/test_operations.py
+++ b/backend/tests/sandbox/test_operations.py
@@ -34,6 +34,14 @@ class TestResolveAssetPath:
         assert result is not None
         assert "chunk.js" in result
 
+    def test_public_base_prefix_is_removed(self, tmp_path) -> None:  # type: ignore[type-arg]
+        dist = tmp_path / "dist"
+        (dist / "assets").mkdir(parents=True)
+
+        result = _resolve_asset_path(str(dist), "/shared/my-app/assets/chunk.js")
+
+        assert result == str(dist / "assets" / "chunk.js")
+
 
 class TestInlineCssAssets:
     def test_inlines_stylesheet(self, tmp_path) -> None:  # type: ignore[type-arg]

--- a/backend/tests/sandbox/test_pnpm_routing.py
+++ b/backend/tests/sandbox/test_pnpm_routing.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_configure_preview_paths_writes_project_base(sandbox, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    sandbox._configure_preview_paths()
+
+    content = (tmp_path / ".env.local").read_text(encoding="utf-8")
+    assert "VITE_BASE=/api/preview/test/proxy/" in content
+    assert "VITE_BASE_PATH=/api/preview/test/proxy/" in content
+    assert "VITE_API_BASE=" in content

--- a/backend/tests/test_paths.py
+++ b/backend/tests/test_paths.py
@@ -1,0 +1,18 @@
+from flow44.paths import preview_base_path, sandbox_path_env, shared_base_path, strip_public_base_prefix
+
+
+def test_public_base_paths() -> None:
+    assert preview_base_path("project-1") == "/api/preview/project-1/proxy/"
+    assert shared_base_path("my-app") == "/shared/my-app/"
+
+
+def test_sandbox_path_env_supports_old_and_new_vite_configs() -> None:
+    env = sandbox_path_env(public_base="/shared/my-app/", api_base_url="https://api.example")
+    assert env["VITE_BASE"] == "/shared/my-app/"
+    assert env["VITE_BASE_PATH"] == "/shared/my-app/"
+    assert env["VITE_API_BASE"] == "https://api.example"
+
+
+def test_strip_public_base_prefix() -> None:
+    assert strip_public_base_prefix("/shared/my-app/assets/main.js") == "assets/main.js"
+    assert strip_public_base_prefix("/api/preview/project-1/proxy/assets/main.js") == "assets/main.js"

--- a/backend/tests/test_router_basename.py
+++ b/backend/tests/test_router_basename.py
@@ -1,0 +1,17 @@
+"""Tests for platform routerBasename helper in the project template."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from flow44.config import settings
+
+
+def test_router_basename_uses_base_url() -> None:
+    path = Path(settings.TEMPLATE_DIR) / "src" / "platform" / "react-router-dom" / "routerBasename.ts"
+    content = path.read_text(encoding="utf-8")
+    assert "getRouterBasename" in content
+    assert "import.meta.env.BASE_URL" in content
+    assert "VITE_BASE_PATH" not in content
+    assert "querySelector('base')" not in content
+    assert "replace(/" in content and "/+$/" in content

--- a/backend/tests/test_template_platform.py
+++ b/backend/tests/test_template_platform.py
@@ -1,0 +1,87 @@
+"""Tests for template platform routing ownership and contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from flow44.config import settings
+
+
+@pytest.fixture
+def template_root() -> Path:
+    return Path(settings.TEMPLATE_DIR)
+
+
+def test_react_router_platform_readme_exists(template_root: Path) -> None:
+    routing_md = template_root / "src" / "platform" / "react-router-dom" / "README.md"
+    assert routing_md.is_file()
+    content = routing_md.read_text(encoding="utf-8")
+    assert "getRouterBasename" in content
+    assert "./platform/react-router-dom/routerBasename" in content
+    assert "Link" in content
+    assert "Do not edit" in content or "do not edit" in content.lower()
+    assert "vite.config.ts" in content
+    assert "never use `<a href=\"/...\">`" in content.lower()
+
+
+def test_vite_config_does_not_override_base_url_define(template_root: Path) -> None:
+    content = (template_root / "vite.config.ts").read_text(encoding="utf-8")
+    assert "import.meta.env.BASE_URL" not in content
+    assert "env.BASE_URL" not in content
+
+
+def test_no_flowbolt_stub(template_root: Path) -> None:
+    assert not (template_root / "flowbolt-stub").exists()
+    assert not (template_root / "platform-stub").exists()
+
+
+def test_no_flowbolt_paths_in_template(template_root: Path) -> None:
+    skip_dirs = {"node_modules", "dist", ".git"}
+    for path in template_root.rglob("*"):
+        if any(part in skip_dirs for part in path.parts):
+            continue
+        if path.is_file() and path.suffix in {".ts", ".tsx", ".md", ".json"}:
+            text = path.read_text(encoding="utf-8", errors="replace")
+            assert "flowbolt" not in text.lower(), f"flowbolt reference in {path.relative_to(template_root)}"
+
+
+def test_vite_config_uses_public_base_path(template_root: Path) -> None:
+    content = (template_root / "vite.config.ts").read_text(encoding="utf-8")
+    assert "VITE_BASE_PATH" in content
+    assert "const base = env.VITE_BASE_PATH" in content or "env.VITE_BASE_PATH" in content
+    assert "base," in content or "base:" in content
+
+
+def test_index_html_has_no_base_tag(template_root: Path) -> None:
+    content = (template_root / "index.html").read_text(encoding="utf-8")
+    assert "<base" not in content.lower()
+
+
+def test_platform_router_basename_always_present(template_root: Path) -> None:
+    path = template_root / "src" / "platform" / "react-router-dom" / "routerBasename.ts"
+    assert path.is_file()
+
+
+def test_router_platform_folder_present(template_root: Path) -> None:
+    platform = template_root / "src" / "platform"
+    assert (platform / "react-router-dom").is_dir()
+    assert (platform / "react-router-dom" / "README.md").is_file()
+
+
+def test_no_platform_app_router_in_template(template_root: Path) -> None:
+    assert not (template_root / "src" / "platform" / "AppRouter.tsx").exists()
+
+
+def test_main_tsx_renders_app_directly(template_root: Path) -> None:
+    content = (template_root / "src" / "main.tsx").read_text(encoding="utf-8")
+    assert "<App />" in content or "<App/>" in content
+    assert "BrowserRouter" not in content
+    assert "react-router-dom" not in content
+
+
+def test_package_json_no_react_router_by_default(template_root: Path) -> None:
+    pkg = json.loads((template_root / "package.json").read_text(encoding="utf-8"))
+    assert "react-router-dom" not in pkg.get("dependencies", {})


### PR DESCRIPTION
## Summary
- add React Router as an optional generated-app package with basename-safe prompt rules
- configure preview and published builds with public base paths
- publish complete Vite dist directories and serve shared assets with SPA fallback
- add routing, template, shared-serving, and publishing regression tests
- remove generated-app protected-root directory rules from the AI builder contract and prompts
- align the typed prompt safety context with protected-root rule removal
- centralize shared agent prompt template path constants

## Stack
- PR 3 of 3
- depends on #143
- shared prompt ownership cleanup is split into the correct lower stack layers: file-safety partials and explicit render typing in #138, optional-package prompt ownership in #143
- excludes ReGraph, Leaflet, table packages, lockfile churn, and local Docker changes

## Validation
- focused routing and publishing tests: 87 passed
- Ruff checks passed
- `git diff --cached --check`
- `uv run ruff check src/flow44/ai/generated_app_contract.py src/flow44/ai/agents/plan/prompts.py src/flow44/ai/agents/followup/prompts.py src/flow44/ai/agents/execute/prompts.py src/flow44/ai/agents/fix_error/prompts.py`: passed
- `UV_CACHE_DIR=/tmp/flowbolt-uv-cache uv run mypy --config-file mypy.toml src/flow44/ai/generated_app_contract.py src/flow44/ai/agents/plan/prompts.py src/flow44/ai/agents/followup/prompts.py src/flow44/ai/agents/execute/prompts.py src/flow44/ai/agents/fix_error/prompts.py`: passed
- `uv run pytest tests/ai/test_prompts.py tests/ai/agents/test_optional_packages.py tests/ai/agents/execute/test_package_contract_flow.py tests/ai/test_generated_app_contract.py --no-cov`: 49 passed