### PR TITLE
Delete published S3 object with project

### DIFF
--- a/backend/src/flow44/api/projects.py
+++ b/backend/src/flow44/api/projects.py
@@ -21,6 +21,7 @@ from flow44.db.project import (
 )
 from flow44.db.project import list_user_projects as db_list_user_projects
 from flow44.db.project_member import list_shared_projects
+from flow44.integrations.s3 import delete_published_object
 from flow44.sandbox.idle_reaper import idle_reaper
 from flow44.sandbox.manager import sandbox_manager
 
@@ -125,6 +126,7 @@ async def delete_existing_project(
 ) -> None:
     idle_reaper.remove(project.id)
     await delete_project(project.id)
+    background_tasks.add_task(delete_published_object, project.id)
     background_tasks.add_task(sandbox_manager.destroy_sandbox, project.id)
 
 

--- a/backend/src/flow44/integrations/s3.py
+++ b/backend/src/flow44/integrations/s3.py
@@ -72,3 +72,14 @@ def deploy_single_html(html_content: str, project_id: str) -> str:
         StorageClass=settings.S3_STORAGE_CLASS,
     )
     return get_published_url(project_id)
+
+
+def delete_published_object(project_id: str) -> None:
+    """Delete the published S3 object for a project, if S3 is configured."""
+    if not settings.S3_BUCKET_NAME:
+        logger.info("Skipping published object delete for project %s: S3 bucket is not configured.", project_id)
+        return
+
+    s3 = connect_to_s3()
+    key = _get_s3_key(project_id)
+    s3.delete_object(Bucket=settings.S3_BUCKET_NAME, Key=key)

--- a/backend/tests/api/test_projects.py
+++ b/backend/tests/api/test_projects.py
@@ -1,0 +1,24 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import BackgroundTasks
+
+from flow44.api.projects import delete_existing_project
+from flow44.db.project import Project
+
+
+@pytest.mark.asyncio
+async def test_delete_existing_project_schedules_s3_cleanup():
+    project = Project(id="proj-123", user_id="user-1", name="App")
+    background_tasks = MagicMock(spec=BackgroundTasks)
+
+    with (
+        patch("flow44.api.projects.idle_reaper.remove") as mock_idle_remove,
+        patch("flow44.api.projects.delete_project", new=AsyncMock()) as mock_delete_project,
+        patch("flow44.api.projects.delete_published_object") as mock_delete_published_object,
+    ):
+        await delete_existing_project(project, background_tasks, _perms=set())
+
+    mock_idle_remove.assert_called_once_with("proj-123")
+    mock_delete_project.assert_awaited_once_with("proj-123")
+    background_tasks.add_task.assert_any_call(mock_delete_published_object, "proj-123")

--- a/backend/tests/integrations/test_s3_integration.py
+++ b/backend/tests/integrations/test_s3_integration.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from flow44.config import settings
-from flow44.integrations.s3 import connect_to_s3, deploy_single_html, setup_bucket
+from flow44.integrations.s3 import connect_to_s3, delete_published_object, deploy_single_html, setup_bucket
 
 
 @pytest.fixture(autouse=True)
@@ -49,17 +49,37 @@ def test_deploy_single_html():
         project_id = "proj-123"
 
         # Ensure settings are controlled
-        with patch.object(settings, "S3_BUCKET_NAME", "my-bucket"):
-            with patch.object(settings, "S3_ENDPOINT_URL", "http://s3.local"):
-                url = deploy_single_html(html_content, project_id)
+        with (
+            patch.object(settings, "S3_BUCKET_NAME", "my-bucket"),
+            patch.object(settings, "S3_ENDPOINT_URL", "http://s3.local"),
+        ):
+            url = deploy_single_html(html_content, project_id)
 
-                expected_key = f"published/{project_id}.html"
-                mock_client.put_object.assert_called_once_with(
-                    Bucket="my-bucket",
-                    Key=expected_key,
-                    Body=html_content.encode("utf-8"),
-                    ContentType="text/html",
-                    ACL="public-read",
-                    StorageClass=settings.S3_STORAGE_CLASS,
-                )
-                assert url == f"http://s3.local/my-bucket/{expected_key}"
+            expected_key = f"published/{project_id}.html"
+            mock_client.put_object.assert_called_once_with(
+                Bucket="my-bucket",
+                Key=expected_key,
+                Body=html_content.encode("utf-8"),
+                ContentType="text/html",
+                ACL="public-read",
+                StorageClass=settings.S3_STORAGE_CLASS,
+            )
+            assert url == f"http://s3.local/my-bucket/{expected_key}"
+
+
+def test_delete_published_object():
+    with patch("flow44.integrations.s3.connect_to_s3") as mock_connect:
+        mock_client = MagicMock()
+        mock_connect.return_value = mock_client
+
+        with patch.object(settings, "S3_BUCKET_NAME", "my-bucket"):
+            delete_published_object("proj-123")
+
+        mock_client.delete_object.assert_called_once_with(Bucket="my-bucket", Key="published/proj-123.html")
+
+
+def test_delete_published_object_skips_when_bucket_is_not_configured():
+    with patch("flow44.integrations.s3.connect_to_s3") as mock_connect, patch.object(settings, "S3_BUCKET_NAME", None):
+        delete_published_object("proj-123")
+
+    mock_connect.assert_not_called()


### PR DESCRIPTION
## Summary
- add an S3 helper to delete the published project object
- schedule published object cleanup when a project is deleted
- cover S3 deletion and delete endpoint task registration with tests

## Tests
- uv run pytest --no-cov tests/api/test_projects.py tests/integrations/test_s3_integration.py
- uv run ruff check --config ruff.toml src/flow44/api/projects.py src/flow44/integrations/s3.py tests/api/test_projects.py tests/integrations/test_s3_integration.py
- uv run ruff format --check --config ruff.toml src/flow44/api/projects.py src/flow44/integrations/s3.py tests/api/test_projects.py tests/integrations/test_s3_integration.py