### PR TITLE
Bugfix: upgrade _ts_ident to support identifier that starts with a digit

### DIFF
--- a/backend/src/flow44/ai/codegen/data_source_module.py
+++ b/backend/src/flow44/ai/codegen/data_source_module.py
@@ -201,6 +201,8 @@ def _ts_ident(name: str) -> str:
     parts = re.split(r"_+", name)
     head, *rest = parts
     ident = head + "".join(p[:1].upper() + p[1:] for p in rest if p)
+    if ident[:1].isdigit():
+        ident = "_" + ident
     if ident in _TS_RESERVED:
         return f"{ident}_"
     return ident

--- a/backend/tests/ai/codegen/test_data_source_module.py
+++ b/backend/tests/ai/codegen/test_data_source_module.py
@@ -403,6 +403,43 @@ class TestCubeIdDisambiguation:
         assert "body['filters']['start_date'] = filters_startDate;" in result
         assert "if (limit !== undefined) {\n    body['reports']['limit'] = limit;\n  }" in result
 
+    def test_numeric_cube_id_prefix_is_valid_ts_identifier(self) -> None:
+        # cube_id starting with a digit gets a leading underscore so the
+        # generated identifier is valid TS (identifiers cannot start with a digit).
+        params = DataSourceParamsInfo(
+            parameters=[
+                ParamDefinition(
+                    name="start_date",
+                    display_name="Start date",
+                    type="datetime",
+                    is_required=True,
+                    is_single_value=True,
+                    options=[],
+                    cube_id="1reports",
+                ),
+                ParamDefinition(
+                    name="start_date",
+                    display_name="Start date",
+                    type="datetime",
+                    is_required=True,
+                    is_single_value=True,
+                    options=[],
+                    cube_id="2filters",
+                ),
+            ],
+            require_any=False,
+        )
+        result = generate_data_source_module(
+            data_source_id="10",
+            sanitized_name="Report",
+            params_info=params,
+            queries=_queries("report"),
+        )
+        assert "_1reports_startDate: { From: Date; To: Date }" in result
+        assert "_2filters_startDate: { From: Date; To: Date }" in result
+        assert "body['1reports']['start_date'] = _1reports_startDate;" in result
+        assert "body['2filters']['start_date'] = _2filters_startDate;" in result
+
 
 class TestAllParamTypes:
     def test_all_four_param_types_map_to_correct_ts_types(self) -> None:


### PR DESCRIPTION
the generated module is not valid typescript when it hits the same-param-name disambiguation and the cube id starts with a digit making it an invalid field name