### PR TITLE
UI polish: chat timestamps, sidebar project search, and assorted UI-quirk fixes

### DIFF
--- a/backend/src/flow44/db/events.py
+++ b/backend/src/flow44/db/events.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from sqlalchemy import JSON, Column, DateTime, ForeignKey, String, func
@@ -67,6 +67,7 @@ class AgentEvent(SQLModel, table=True):
 
 async def emit_event(project_id: str, event: dict[str, Any], *, notify: bool = True) -> None:
     event_type = event.get("type", "unknown")
+    event.setdefault("_ts", datetime.now(UTC).isoformat())
 
     async with database.async_session() as session:
         row = AgentEvent(project_id=project_id, event_type=event_type, payload=event)

--- a/frontend/e2e/happy-path.spec.ts
+++ b/frontend/e2e/happy-path.spec.ts
@@ -28,9 +28,9 @@ async function gotoHomeReady(page: import('@playwright/test').Page) {
 /** Wait for projects to load, expand sidebar if collapsed. */
 async function ensureSidebar(page: import('@playwright/test').Page) {
   // Icon rail uses a button with initials; full sidebar uses a non-button row.
-  const rail = page.getByRole('button', { name: 'ET' });
+  const rail = page.getByRole('button', { name: 'ET', exact: true });
   const row = page.getByTestId(`project-item-${MOCK_PROJECT.id}`);
-  await expect(rail.or(row)).toBeVisible({ timeout: 30_000 });
+  await expect(rail.or(row).first()).toBeVisible({ timeout: 30_000 });
   // Expand if collapsed
   const expandBtn = page.getByRole('button', { name: 'Expand sidebar' });
   if (await expandBtn.isVisible()) {

--- a/frontend/e2e/project-lifecycle.spec.ts
+++ b/frontend/e2e/project-lifecycle.spec.ts
@@ -35,7 +35,7 @@ test.describe('Delete project', () => {
     await page.goto('/');
 
     // Wait for project to load
-    await expect(page.getByRole('button', { name: 'ET' })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('button', { name: 'ET', exact: true })).toBeVisible({ timeout: 10_000 });
 
     // Expand sidebar
     const expandBtn = page.getByRole('button', { name: 'Expand sidebar' });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.4.0",
     "i18next": "^25.10.9",
     "jose": "^6.2.3",
     "js-cookie": "^3.0.8",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: ^4.4.0
+        version: 4.4.0
       i18next:
         specifier: ^25.10.9
         version: 25.10.9(typescript@5.9.3)
@@ -501,36 +504,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
@@ -602,24 +611,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -776,6 +789,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -930,6 +944,9 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1271,24 +1288,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2649,6 +2670,8 @@ snapshots:
       which: 2.0.2
 
   csstype@3.2.3: {}
+
+  date-fns@4.4.0: {}
 
   debug@4.4.3:
     dependencies:

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -352,6 +352,33 @@
   animation: cardFadeIn 0.3s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
+.anchored-menu {
+  position-anchor: var(--anchor);
+  position-area: block-end span-inline-start;
+  position-try-fallbacks: flip-block;
+  inset: auto;
+  margin: 2px 0;
+  opacity: 0;
+  transform: scale(0.96);
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease,
+    overlay 0.15s allow-discrete,
+    display 0.15s allow-discrete;
+}
+
+.anchored-menu:popover-open {
+  opacity: 1;
+  transform: scale(1);
+}
+
+@starting-style {
+  .anchored-menu:popover-open {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+}
+
 /* Progress bar shimmer */
 @keyframes shimmer {
   0% { background-position: -200% 0; }

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -1,7 +1,9 @@
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { useTranslation } from 'react-i18next';
 import { FileText, TerminalSquare } from 'lucide-react';
 import type { Message } from '../../types';
+import { formatClock } from '../../utils/formatTime';
 import { Badge } from '../ui/badge';
 import {
   DataSourcesFetchedCard,
@@ -69,23 +71,31 @@ function DataSourceBadges({ dataSources }: { dataSources: { id: number; name: st
 }
 
 export function ChatMessage({ message, isStreaming }: ChatMessageProps) {
+  const { i18n } = useTranslation();
   const isUser = message.role === 'user';
 
   if (!message.content && !message.agentCard && !message.actions?.length && !isStreaming) {
     return null;
   }
 
+  const timestamp = !isStreaming && (
+    <span className="px-1 text-[11px] text-muted-foreground/60 opacity-0 group-hover:opacity-100 transition-opacity">
+      {formatClock(message.timestamp, i18n.language)}
+    </span>
+  );
+
   // Agent card messages
   if (message.agentCard) {
     return (
-      <div className={`flex w-full ${isUser ? 'justify-start' : 'justify-end'} animate-message-in`}>
+      <div className={`group flex flex-col w-full ${isUser ? 'items-start' : 'items-end'} animate-message-in`}>
         <AgentCardRenderer message={message} />
+        {message.agentCard.type === 'error_fix_request' && timestamp}
       </div>
     );
   }
 
   return (
-    <div className={`flex w-full ${isUser ? 'justify-start' : 'justify-end'} animate-message-in`}>
+    <div className={`group flex flex-col w-full ${isUser ? 'items-start' : 'items-end'} animate-message-in`}>
       <div
         className={`min-w-0 max-w-[85%] overflow-hidden px-3.5 py-2.5 rounded-xl text-sm leading-relaxed ${
           isUser ? 'bg-user-bubble border border-primary/30' : 'bg-assistant-bubble border border-border'
@@ -147,6 +157,7 @@ export function ChatMessage({ message, isStreaming }: ChatMessageProps) {
           </div>
         )}
       </div>
+      {timestamp}
     </div>
   );
 }

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useRef, useState, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ArrowDown } from 'lucide-react';
 import { useChatStore } from '../../stores/chat';
@@ -16,51 +16,48 @@ export function ChatPanel() {
   const { t } = useTranslation();
   const {
     messages, currentAssistantMessage, actions, error, clearError,
-    agentPhase, planOverview, executionTasks, designProgress, fixSteps, followUpSteps, fileDiffs, historyLoaded,
+    agentPhase, planOverview, executionTasks, designProgress, fixSteps, followUpSteps, fileDiffs,
   } = useChatStore();
   const agentActive = useChatStore(isAgentAlive);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const stickToBottomRef = useRef(true);
   const [showScrollBtn, setShowScrollBtn] = useState(false);
 
-  const scrollToBottom = useCallback(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  const pinToBottom = useCallback(() => {
+    const el = scrollContainerRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
   }, []);
 
-  // Auto-scroll on new content
-  useEffect(() => {
-    const el = scrollContainerRef.current;
-    if (!el) return;
-    // Only auto-scroll if already near the bottom
-    const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 150;
-    if (isNearBottom) scrollToBottom();
-  }, [messages, currentAssistantMessage, agentPhase, planOverview, executionTasks, fixSteps, followUpSteps, scrollToBottom]);
+  const observeContentForPinning = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return;
+    const observer = new ResizeObserver(() => {
+      if (stickToBottomRef.current) pinToBottom();
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [pinToBottom]);
 
-  // Track scroll position to show/hide the button
-  useEffect(() => {
-    const el = scrollContainerRef.current;
-    if (!el) return;
-    const handleScroll = () => {
-      const distFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-      setShowScrollBtn(distFromBottom > 200);
-    };
-    el.addEventListener('scroll', handleScroll, { passive: true });
-    return () => el.removeEventListener('scroll', handleScroll);
-  }, []);
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget;
+    const distFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    stickToBottomRef.current = distFromBottom < 150;
+    setShowScrollBtn(distFromBottom > 200);
+  };
 
-  // Force scroll to bottom when plan overview appears (including on reconnect)
+  const jumpToBottom = () => {
+    stickToBottomRef.current = true;
+    scrollContainerRef.current?.scrollTo({ top: scrollContainerRef.current.scrollHeight, behavior: 'smooth' });
+  };
+
+  const wasAgentActiveRef = useRef(agentActive);
   useEffect(() => {
-    if (agentPhase === 'awaiting_approval' && planOverview) {
-      setTimeout(scrollToBottom, 100);
+    const runJustStarted = agentActive && !wasAgentActiveRef.current;
+    if (runJustStarted) {
+      stickToBottomRef.current = true;
+      pinToBottom();
     }
-  }, [agentPhase, planOverview, scrollToBottom]);
-
-  // Scroll to bottom on initial history load (after page refresh)
-  useEffect(() => {
-    if (historyLoaded && messages.length > 0) {
-      setTimeout(scrollToBottom, 100);
-    }
-  }, [historyLoaded, scrollToBottom]);
+    wasAgentActiveRef.current = agentActive;
+  }, [agentActive, pinToBottom]);
 
   const showDesignProgress = agentPhase === 'designing';
   const showOverview = agentPhase === 'awaiting_approval' && planOverview;
@@ -74,7 +71,8 @@ export function ChatPanel() {
   return (
     <div className="flex flex-col h-full overflow-hidden relative">
       {/* Messages */}
-      <div ref={scrollContainerRef} className="flex-1 overflow-auto p-4 flex flex-col gap-4 scroll-smooth">
+      <div ref={scrollContainerRef} onScroll={handleScroll} className="flex-1 overflow-auto p-4">
+        <div ref={observeContentForPinning} className="flex flex-col gap-4">
         {messages.map((msg) => (
           <ChatMessage key={msg.id} message={msg} />
         ))}
@@ -118,13 +116,13 @@ export function ChatPanel() {
           />
         )}
 
-        <div ref={messagesEndRef} />
+        </div>
       </div>
 
       {/* Scroll to bottom button */}
       {showScrollBtn && (
         <button
-          onClick={scrollToBottom}
+          onClick={jumpToBottom}
           className="absolute bottom-[120px] start-1/2 -translate-x-1/2 w-8 h-8 rounded-full bg-surface border border-primary/30 shadow-[var(--shadow-md)] flex items-center justify-center text-primary/70 hover:text-primary hover:bg-primary/10 transition-all duration-150 z-10"
           title={t('chat.scrollToBottom')}
         >
@@ -134,9 +132,9 @@ export function ChatPanel() {
 
       {/* Error banner */}
       {error && (
-        <div className="flex items-center justify-between px-4 py-2 bg-danger-bg border-t border-destructive text-destructive text-[13px] shrink-0">
+        <div className="flex items-center justify-between px-4 py-2 bg-warning/10 border-t border-warning text-warning text-[13px] shrink-0">
           <span>{error}</span>
-          <button onClick={clearError} className="text-destructive px-1.5 py-0.5 text-xs">
+          <button onClick={clearError} className="text-warning px-1.5 py-0.5 text-xs">
             Dismiss
           </button>
         </div>

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -1,6 +1,8 @@
 import { useRef, useState, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ArrowDown } from 'lucide-react';
+import { formatDayDivider, sameDay } from '../../utils/formatTime';
+import type { Message } from '../../types';
 import { useChatStore } from '../../stores/chat';
 import { isAgentAlive } from '../../stores/chatAgentState';
 import { ChatMessage } from './ChatMessage';
@@ -12,8 +14,29 @@ import { DesignProgress } from './DesignProgress';
 import { FixProgressCard } from './cards/FixProgressCard';
 import { FollowUpProgress } from './cards/FollowUpProgress';
 
+type DayGroup = { key: string; ts: number; msgs: Message[] };
+
+function groupMessagesByDay(messages: Message[]): DayGroup[] {
+  return messages.reduce<DayGroup[]>((groups, msg) => {
+    const last = groups.at(-1);
+    if (last && sameDay(last.ts, msg.timestamp)) last.msgs.push(msg);
+    else groups.push({ key: msg.id, ts: msg.timestamp, msgs: [msg] });
+    return groups;
+  }, []);
+}
+
+function DayDivider({ label }: { label: string }) {
+  return (
+    <div className="sticky top-0 z-10 flex justify-center pointer-events-none">
+      <span className="pointer-events-auto text-[11px] text-muted-foreground bg-surface border border-border rounded-full px-2.5 py-0.5 shadow-[var(--shadow-sm)] select-none">
+        {label}
+      </span>
+    </div>
+  );
+}
+
 export function ChatPanel() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const {
     messages, currentAssistantMessage, actions, error, clearError,
     agentPhase, planOverview, executionTasks, designProgress, fixSteps, followUpSteps, fileDiffs,
@@ -68,13 +91,20 @@ export function ChatPanel() {
   const showPhaseIndicator = agentPhase === 'planning' || (agentPhase === 'exploring' && followUpSteps.length === 0);
   const showTypingDots = agentActive && !currentAssistantMessage && !showDesignProgress && !showOverview && !showTaskProgress && !showFixProgress && !showFollowUpProgress && !showPhaseIndicator;
 
+  const dayGroups = groupMessagesByDay(messages);
+
   return (
     <div className="flex flex-col h-full overflow-hidden relative">
       {/* Messages */}
       <div ref={scrollContainerRef} onScroll={handleScroll} className="flex-1 overflow-auto p-4">
         <div ref={observeContentForPinning} className="flex flex-col gap-4">
-        {messages.map((msg) => (
-          <ChatMessage key={msg.id} message={msg} />
+        {dayGroups.map((group) => (
+          <div key={group.key} className="flex flex-col gap-4">
+            <DayDivider label={formatDayDivider(group.ts, i18n.language, t)} />
+            {group.msgs.map((msg) => (
+              <ChatMessage key={msg.id} message={msg} />
+            ))}
+          </div>
         ))}
 
         {showPhaseIndicator && <PhaseIndicator phase={agentPhase} />}

--- a/frontend/src/components/chat/DataSourceSelector.tsx
+++ b/frontend/src/components/chat/DataSourceSelector.tsx
@@ -15,9 +15,10 @@ export function DataSourceSelector({ isOpen }: DataSourceSelectorProps) {
   const { t } = useTranslation();
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<DataSourceSearchResult[]>([]);
-  const [showDropdown, setShowDropdown] = useState(false);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const selectedDataSources = useChatStore((s) => s.selectedDataSources);
+  const messages = useChatStore((s) => s.messages);
   const addDataSource = useChatStore((s) => s.addDataSource);
   const removeDataSource = useChatStore((s) => s.removeDataSource);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -25,16 +26,18 @@ export function DataSourceSelector({ isOpen }: DataSourceSelectorProps) {
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) setShowDropdown(false);
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) setIsDropdownOpen(false);
     };
-    if (showDropdown) {
+    if (isDropdownOpen) {
       document.addEventListener('mousedown', handleClickOutside);
       return () => document.removeEventListener('mousedown', handleClickOutside);
     }
-  }, [showDropdown]);
+  }, [isDropdownOpen]);
 
   useEffect(() => {
-    if (isOpen && inputRef.current) inputRef.current.focus();
+    if (!isOpen) return;
+    inputRef.current?.focus();
+    setIsDropdownOpen(true);
   }, [isOpen]);
 
   const debouncedQuery = useDebouncedValue(query, 300);
@@ -42,14 +45,13 @@ export function DataSourceSelector({ isOpen }: DataSourceSelectorProps) {
   useEffect(() => {
     if (!debouncedQuery.trim()) {
       setResults([]);
-      setShowDropdown(false);
       setIsLoading(false);
       return;
     }
 
     let ignore = false;
     setIsLoading(true);
-    setShowDropdown(true);
+    setIsDropdownOpen(true);
 
     (async () => {
       try {
@@ -63,18 +65,23 @@ export function DataSourceSelector({ isOpen }: DataSourceSelectorProps) {
       }
     })();
 
-    return () => {
-      ignore = true;
-    };
+    return () => { ignore = true; };
   }, [debouncedQuery]);
 
   if (!isOpen) return null;
 
-  const handleSelect = (pkg: DataSourceSearchResult) => {
-    addDataSource({ id: pkg.id, name: pkg.name });
+  const dataSourceHistory = messages.flatMap((m) => m.dataSources ?? []);
+  const uniqueDataSources = dataSourceHistory.filter(
+    (ds, i) => dataSourceHistory.findIndex((d) => d.id === ds.id) === i,
+  );
+  const isShowingSuggestions = !debouncedQuery.trim();
+  const visibleDataSources: DataSourceSearchResult[] = isShowingSuggestions ? uniqueDataSources : results;
+
+  const handleSelect = (dataSource: DataSourceSearchResult) => {
+    addDataSource({ id: dataSource.id, name: dataSource.name });
     setQuery('');
     setResults([]);
-    setShowDropdown(false);
+    setIsDropdownOpen(false);
   };
 
   const selectedIds = new Set(selectedDataSources.map((c) => c.id));
@@ -96,45 +103,47 @@ export function DataSourceSelector({ isOpen }: DataSourceSelectorProps) {
       )}
 
       {/* Search input */}
-      <div className={`flex items-center gap-2 px-3 py-2 bg-background border rounded-lg transition-colors ${showDropdown ? 'border-primary' : 'border-border'}`}>
-        <Search size={14} className={`shrink-0 transition-colors ${showDropdown ? 'text-primary' : 'text-muted-foreground'}`} />
+      <div className={`flex items-center gap-2 px-3 py-2 bg-background border rounded-lg transition-colors ${isDropdownOpen ? 'border-primary' : 'border-border'}`}>
+        <Search size={14} className={`shrink-0 transition-colors ${isDropdownOpen ? 'text-primary' : 'text-muted-foreground'}`} />
         <input
           ref={inputRef}
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          onFocus={() => { if (results.length > 0) setShowDropdown(true); }}
+          onFocus={() => setIsDropdownOpen(true)}
           placeholder={t('chat.dataSource.searchPlaceholder')}
           className="flex-1 text-[13px] bg-transparent"
         />
       </div>
 
       {/* Dropdown results */}
-      {showDropdown && (
+      {isDropdownOpen && (isLoading || visibleDataSources.length > 0 || !isShowingSuggestions) && (
         <div className="absolute bottom-full start-0 end-0 mb-1 max-h-60 overflow-y-auto bg-popover border border-border rounded-lg shadow-[var(--shadow-md)] z-[1000]">
           {isLoading ? (
             <div className="p-3 text-center text-[13px] text-muted-foreground">Searching...</div>
-          ) : results.length === 0 ? (
+          ) : visibleDataSources.length === 0 ? (
             <div className="p-3 text-center text-[13px] text-muted-foreground">No data sources found</div>
           ) : (
-            results.map((pkg) => {
-              const alreadySelected = selectedIds.has(pkg.id);
+            visibleDataSources.map((dataSource) => {
+              const alreadySelected = selectedIds.has(dataSource.id);
               return (
                 <button
-                  key={pkg.id}
-                  onClick={() => !alreadySelected && handleSelect(pkg)}
+                  key={dataSource.id}
+                  onClick={() => !alreadySelected && handleSelect(dataSource)}
                   disabled={alreadySelected}
                   className={`w-full px-3 py-2.5 text-left border-b border-border transition-colors ${
                     alreadySelected ? 'opacity-50 cursor-default' : 'cursor-pointer hover:bg-[color-mix(in_srgb,var(--primary)_8%,transparent)]'
                   }`}
                 >
                   <div className="text-[13px] font-medium mb-0.5">
-                    {pkg.name}
+                    {dataSource.name}
                     {alreadySelected && <span className="text-muted-foreground font-normal"> (selected)</span>}
                   </div>
-                  {pkg.description && (
-                    <div className="text-xs text-muted-foreground truncate">{pkg.description}</div>
-                  )}
+                  {isShowingSuggestions ? (
+                    <div className="text-xs text-muted-foreground">{t('chat.dataSource.usedInProject')}</div>
+                  ) : dataSource.description ? (
+                    <div className="text-xs text-muted-foreground truncate">{dataSource.description}</div>
+                  ) : null}
                 </button>
               );
             })

--- a/frontend/src/components/chat/cards/ErrorFixRequestCard.tsx
+++ b/frontend/src/components/chat/cards/ErrorFixRequestCard.tsx
@@ -11,8 +11,8 @@ export function ErrorFixRequestCard({ errorMessage, errorFile, errorLine, errorS
   const [isExpanded, setIsExpanded] = useState(false);
 
   return (
-    <CardWrapper accent="destructive">
-      <div className="flex items-center gap-1.5 mb-2 text-xs text-destructive">
+    <CardWrapper accent="warning">
+      <div className="flex items-center gap-1.5 mb-2 text-xs text-warning">
         <AlertTriangle size={14} />
         Fix error request
       </div>
@@ -36,7 +36,7 @@ export function ErrorFixRequestCard({ errorMessage, errorFile, errorLine, errorS
       {isExpanded && (
         <div className="p-2 bg-background rounded-md text-xs leading-normal">
           <div className={errorStack ? 'mb-2' : ''}>
-            <strong className="text-destructive">Message:</strong>
+            <strong className="text-warning">Message:</strong>
             <div className="mt-1">{errorMessage}</div>
           </div>
 

--- a/frontend/src/components/errors/ErrorToast.tsx
+++ b/frontend/src/components/errors/ErrorToast.tsx
@@ -40,11 +40,15 @@ function SingleErrorToast({ error }: { error: AppError }) {
     }
   };
 
+  const isConnection = error.source === 'connection';
+  const borderClass = isConnection ? 'border-destructive' : 'border-warning';
+  const textClass = isConnection ? 'text-destructive' : 'text-warning';
+
   return (
-    <div className="flex items-start gap-2.5 p-3 bg-card border border-destructive rounded-lg max-w-[420px] shadow-[var(--shadow-lg)]">
-      <AlertTriangle size={18} className="text-destructive shrink-0 mt-0.5" />
+    <div className={`flex items-start gap-2.5 p-3 bg-card border ${borderClass} rounded-lg max-w-[420px] shadow-[var(--shadow-lg)]`}>
+      <AlertTriangle size={18} className={`${textClass} shrink-0 mt-0.5`} />
       <div className="flex-1 min-w-0">
-        <div className="text-[11px] font-semibold text-destructive uppercase tracking-wider mb-1">
+        <div className={`text-[11px] font-semibold ${textClass} uppercase tracking-wider mb-1`}>
           {error.source === 'build' ? t('errors.buildError') : error.source === 'runtime' ? t('errors.runtimeError') : error.source === 'console' ? t('errors.consoleError') : t('errors.connectionError')}
         </div>
         <div className="text-[13px] leading-snug break-words">

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Sidebar } from './Sidebar';
 import { GlobalProgress } from './GlobalProgress';
@@ -8,14 +8,17 @@ import { FlexibleLayout } from './FlexibleLayout';
 import { MobileLayout } from './MobileLayout';
 import { BottomDrawer } from './BottomDrawer';
 import { PublishModal } from '../publish/PublishModal';
+import { AdminPanel } from '../admin/AdminPanel';
 import { FlowBrand, FlowLogo } from '../ui/flow-logo';
 import { PromptInput } from '../chat/PromptInput';
+import { Settings, Shield } from 'lucide-react';
 import { useChatStore } from '../../stores/chat';
 import { useSessionStore } from '../../stores/session';
 import { useFilesStore } from '../../stores/files';
 import { useIsMobile } from '../../hooks/useIsMobile';
 
 const SIDEBAR_WIDTH = 280;
+const RAIL_WIDTH = 56;
 type LayoutMode = 'classic' | 'flexible';
 
 function loadLayoutMode(): LayoutMode {
@@ -24,6 +27,14 @@ function loadLayoutMode(): LayoutMode {
     if (v === 'classic' || v === 'flexible') return v;
   } catch {}
   return 'classic';
+}
+
+function loadSidebarExpanded(): boolean {
+  try {
+    return localStorage.getItem('sidebar-expanded') === 'true';
+  } catch {
+    return false;
+  }
 }
 
 function getProjectHasMessages(projectId: string): boolean | null {
@@ -47,26 +58,17 @@ export function AppShell() {
   const { t } = useTranslation();
   const isMobile = useIsMobile();
 
-  // All hooks must be called before any conditional returns
-  // Sidebar
-  const [sidebarPinned, setSidebarPinned] = useState(false);
-  const [sidebarHover, setSidebarHover] = useState(false);
-  const [sidebarClosing, setSidebarClosing] = useState(false);
-  const [sidebarBusy, setSidebarBusy] = useState(false);
-  const hoverLockRef = useRef(false);
+  const [sidebarExpanded, setSidebarExpanded] = useState(loadSidebarExpanded);
 
-  const closeSidebar = () => {
-    setSidebarPinned(false);
-    setSidebarHover(false);
-    setSidebarClosing(true);
-    hoverLockRef.current = true;
-    setTimeout(() => { setSidebarClosing(false); hoverLockRef.current = false; }, 250);
+  const toggleSidebar = (expanded: boolean) => {
+    setSidebarExpanded(expanded);
+    try { localStorage.setItem('sidebar-expanded', expanded ? 'true' : 'false'); } catch {}
   };
-
 
   // Layout + settings
   const [layoutMode, setLayoutMode] = useState<LayoutMode>(loadLayoutMode);
   const [showSettings, setShowSettings] = useState(false);
+  const [showAdminPanel, setShowAdminPanel] = useState(false);
 
   const switchLayout = (mode: LayoutMode) => {
     setLayoutMode(mode);
@@ -79,6 +81,7 @@ export function AppShell() {
   const historyLoaded = useChatStore((s) => s.historyLoaded);
   const projects = useSessionStore((s) => s.projects);
   const currentProject = useSessionStore((s) => s.currentProject);
+  const userStatus = useSessionStore((s) => s.userStatus);
 
   // Use cache to determine layout before history loads to prevent flicker
   // Read project ID from URL hash immediately (don't wait for currentProject to be set)
@@ -133,7 +136,7 @@ export function AppShell() {
 
   const IconRail = () => (
     <div className="flex flex-col items-center h-full py-2 gap-1">
-      <button onClick={() => setSidebarPinned(true)} title={t('sidebar.expandSidebar')} className="mb-1 shrink-0">
+      <button onClick={() => toggleSidebar(true)} title={t('sidebar.expandSidebar')} className="mb-1 shrink-0">
         <FlowLogo size={18} className="text-brand" />
       </button>
       <div className="w-8 h-px bg-border shrink-0" />
@@ -153,6 +156,23 @@ export function AppShell() {
           </button>
         ))}
       </div>
+      <div className="w-8 h-px bg-border shrink-0" />
+      {userStatus?.is_admin && (
+        <button
+          onClick={() => setShowAdminPanel(true)}
+          title={t('admin.title', 'Platform Users')}
+          className="w-8 h-8 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-colors shrink-0"
+        >
+          <Shield size={16} className="text-warning/70" />
+        </button>
+      )}
+      <button
+        onClick={() => setShowSettings(true)}
+        title={t('common.settings')}
+        className="w-8 h-8 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-colors shrink-0"
+      >
+        <Settings size={16} className="text-primary/70" />
+      </button>
     </div>
   );
 
@@ -161,35 +181,23 @@ export function AppShell() {
 
   return (
     <div className="flex flex-row h-full w-full overflow-hidden" style={{ boxShadow: 'inset 0 1px 0 0 rgba(255,255,255,0.03)' }}>
-      {/* Sidebar */}
-      {sidebarPinned ? (
+      <div
+        className="relative shrink-0 h-full bg-surface border-e border-border overflow-hidden transition-[width] duration-200 ease-out"
+        style={{ width: sidebarExpanded ? SIDEBAR_WIDTH : RAIL_WIDTH }}
+      >
         <div
-          className="shrink-0 bg-surface border-e border-border flex flex-col animate-[slideIn_0.25s_ease-out]"
+          className={`absolute inset-y-0 start-0 transition-opacity duration-150 ${sidebarExpanded ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}
+          style={{ width: RAIL_WIDTH }}
+        >
+          <IconRail />
+        </div>
+        <div
+          className={`absolute inset-y-0 start-0 transition-opacity duration-150 ${sidebarExpanded ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
           style={{ width: SIDEBAR_WIDTH }}
         >
-          <Sidebar onCloseSidebar={closeSidebar} isPinned={true} onPin={() => setSidebarPinned(true)} onOpenSettings={() => setShowSettings(true)} onBusyChange={setSidebarBusy} />
+          <Sidebar onCollapse={() => toggleSidebar(false)} onOpenSettings={() => setShowSettings(true)} onOpenAdmin={() => setShowAdminPanel(true)} />
         </div>
-      ) : (
-        <div
-          className="relative shrink-0"
-          onMouseEnter={() => { if (!hoverLockRef.current) setSidebarHover(true); }}
-          onMouseLeave={() => { if (!sidebarBusy) closeSidebar(); }}
-        >
-          <div className="w-14 h-full bg-surface border-e border-border flex flex-col">
-            <IconRail />
-          </div>
-          {(sidebarHover || sidebarClosing) && (
-            <div
-              className={`absolute top-0 start-0 z-30 h-full bg-surface border-e border-border shadow-[var(--shadow-lg)] ${
-                sidebarClosing ? 'animate-[slideOut_0.2s_ease-in_forwards]' : 'animate-[slideIn_0.25s_ease-out]'
-              }`}
-              style={{ width: SIDEBAR_WIDTH }}
-            >
-              <Sidebar onCloseSidebar={closeSidebar} isPinned={false} onPin={() => { setSidebarPinned(true); setSidebarHover(false); }} onOpenSettings={() => setShowSettings(true)} onBusyChange={setSidebarBusy} />
-            </div>
-          )}
-        </div>
-      )}
+      </div>
 
       {/* Main content */}
       <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
@@ -247,6 +255,8 @@ export function AppShell() {
           onClose={() => setShowSettings(false)}
         />
       )}
+
+      {showAdminPanel && <AdminPanel onClose={() => setShowAdminPanel(false)} />}
 
       <PublishModal />
     </div>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -186,13 +186,15 @@ export function AppShell() {
         style={{ width: sidebarExpanded ? SIDEBAR_WIDTH : RAIL_WIDTH }}
       >
         <div
-          className={`absolute inset-y-0 start-0 transition-opacity duration-150 ${sidebarExpanded ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}
+          inert={sidebarExpanded}
+          className={`absolute inset-y-0 start-0 transition-opacity duration-150 ${sidebarExpanded ? 'opacity-0' : 'opacity-100'}`}
           style={{ width: RAIL_WIDTH }}
         >
           <IconRail />
         </div>
         <div
-          className={`absolute inset-y-0 start-0 transition-opacity duration-150 ${sidebarExpanded ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+          inert={!sidebarExpanded}
+          className={`absolute inset-y-0 start-0 transition-opacity duration-150 ${sidebarExpanded ? 'opacity-100' : 'opacity-0'}`}
           style={{ width: SIDEBAR_WIDTH }}
         >
           <Sidebar onCollapse={() => toggleSidebar(false)} onOpenSettings={() => setShowSettings(true)} onOpenAdmin={() => setShowAdminPanel(true)} />

--- a/frontend/src/components/layout/MobileLayout.tsx
+++ b/frontend/src/components/layout/MobileLayout.tsx
@@ -87,7 +87,7 @@ export function MobileLayout() {
         <div className="fixed inset-0 z-50 flex">
           <div className="absolute inset-0 bg-black/50" onClick={() => setSidebarOpen(false)} />
           <div className="relative w-[280px] h-full bg-surface border-e border-border shadow-2xl animate-[slideIn_0.2s_ease-out]">
-            <Sidebar onCloseSidebar={() => setSidebarOpen(false)} />
+            <Sidebar onCollapse={() => setSidebarOpen(false)} />
           </div>
         </div>
       )}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSessionStore } from '../../stores/session';
 import { useChatStore } from '../../stores/chat';
@@ -38,6 +38,8 @@ function getProjectColor(name: string) {
   return PROJECT_COLORS[Math.abs(hash) % PROJECT_COLORS.length];
 }
 
+const anchorName = (id: string) => `--a${id.replace(/-/g, '')}`;
+
 function getInitials(name: string) {
   const words = name.trim().split(/\s+/);
   if (words.length >= 2) return (words[0][0] + words[1][0]).toUpperCase();
@@ -55,24 +57,14 @@ export function Sidebar({ onCollapse, onOpenSettings, onOpenAdmin }: SidebarProp
   const [summaryModal, setSummaryModal] = useState<{ projectName: string; summary: ProjectSummary } | null>(null);
   const [shareModal, setShareModal] = useState<{ projectId: string; projectName: string; ownerUserId?: string } | null>(null);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
-  const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
+  const [menuProjectId, setMenuProjectId] = useState<string | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
   const canCreate = userStatus?.is_platform_user || userStatus?.is_admin;
 
-  useEffect(() => {
-    if (!menuOpenId) return;
-    const handler = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenuOpenId(null);
-        setPendingDeleteId(null);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [menuOpenId]);
+  const closeMenu = () => menuRef.current?.hidePopover();
 
   const handleCreate = async () => {
     const name = newName.trim() || 'New Project';
@@ -102,7 +94,7 @@ export function Sidebar({ onCollapse, onOpenSettings, onOpenAdmin }: SidebarProp
       return;
     }
     setPendingDeleteId(null);
-    setMenuOpenId(null);
+    closeMenu();
     const wasSelected = currentProject?.id === id;
     await deleteProject(id);
     if (wasSelected) {
@@ -122,7 +114,7 @@ export function Sidebar({ onCollapse, onOpenSettings, onOpenAdmin }: SidebarProp
   };
 
   const startRename = (project: typeof projects[number]) => {
-    setMenuOpenId(null);
+    closeMenu();
     setRenamingId(project.id);
     setRenameValue(project.name);
   };
@@ -137,7 +129,7 @@ export function Sidebar({ onCollapse, onOpenSettings, onOpenAdmin }: SidebarProp
   };
 
   const handleShowSummary = (project: typeof projects[number]) => {
-    setMenuOpenId(null);
+    closeMenu();
     if (!project.summary) return;
     try {
       const parsedSummary = JSON.parse(project.summary) as ProjectSummary;
@@ -147,6 +139,7 @@ export function Sidebar({ onCollapse, onOpenSettings, onOpenAdmin }: SidebarProp
     }
   };
 
+  const menuProject = projects.find((p) => p.id === menuProjectId);
   const canSearchProjects = projects.length > 10;
   const normalizedSearch = canSearchProjects ? searchQuery.trim().toLowerCase() : '';
   const visibleProjects = normalizedSearch
@@ -228,10 +221,9 @@ export function Sidebar({ onCollapse, onOpenSettings, onOpenAdmin }: SidebarProp
       <div className="flex-1 overflow-auto px-2">
         {visibleProjects.map((project) => {
           const isActive = currentProject?.id === project.id;
-          const isMenuOpen = menuOpenId === project.id;
           const colorClass = getProjectColor(project.name);
           return (
-            <div key={project.id} className="relative">
+            <div key={project.id}>
               <div
                 onClick={() => handleSelect(project)}
                 data-testid={`project-item-${project.id}`}
@@ -268,81 +260,20 @@ export function Sidebar({ onCollapse, onOpenSettings, onOpenAdmin }: SidebarProp
                 <Button
                   variant="ghost"
                   size="icon-sm"
+                  popoverTarget="project-menu"
                   onClick={(e) => {
                     e.stopPropagation();
-                    setMenuOpenId(isMenuOpen ? null : project.id);
-                    setPendingDeleteId(null);
+                    if (menuProjectId !== project.id && menuRef.current?.matches(':popover-open')) {
+                      e.preventDefault();
+                    }
+                    setMenuProjectId(project.id);
                   }}
+                  style={{ anchorName: anchorName(project.id) } as CSSProperties}
                   className="opacity-0 group-hover:opacity-40 hover:!opacity-100 shrink-0"
                 >
                   <MoreHorizontal size={14} />
                 </Button>
               </div>
-
-              {isMenuOpen && (
-                <div
-                  ref={menuRef}
-                  className="absolute end-2 top-full z-50 mt-0.5 min-w-[140px] bg-popover border border-border rounded-lg shadow-[var(--shadow-lg)] py-1 animate-card-in"
-                >
-                  {(!project.role || MANAGE_ROLES.has(project.role)) && (
-                    <button
-                      onClick={() => startRename(project)}
-                      className="w-full flex items-center gap-2 px-3 py-1.5 text-[13px] text-foreground hover:bg-muted/50 transition-colors text-left"
-                    >
-                      <Pencil size={13} className="text-muted-foreground" />
-                      {t('sidebar.rename')}
-                    </button>
-                  )}
-                  {project.summary && (
-                    <button
-                      onClick={() => handleShowSummary(project)}
-                      className="w-full flex items-center gap-2 px-3 py-1.5 text-[13px] text-foreground hover:bg-muted/50 transition-colors text-left"
-                    >
-                      <Info size={13} className="text-muted-foreground" />
-                      {t('sidebar.summary')}
-                    </button>
-                  )}
-                  {(!project.role || MANAGE_ROLES.has(project.role)) && (
-                    <button
-                      onClick={() => {
-                        setMenuOpenId(null);
-                        setShareModal({ projectId: project.id, projectName: project.name, ownerUserId: project.user_id });
-                      }}
-                      className="w-full flex items-center gap-2 px-3 py-1.5 text-[13px] text-foreground hover:bg-muted/50 transition-colors text-left"
-                    >
-                      <Share2 size={13} className="text-muted-foreground" />
-                      {t('sharing.share', 'Share')}
-                    </button>
-                  )}
-                  {isSpecialUser() && (
-                    <button
-                      onClick={async () => {
-                        setMenuOpenId(null);
-                        try {
-                          await reapProject(project.id);
-                        } catch { /* sandbox may already be reaped */ }
-                      }}
-                      className="w-full flex items-center gap-2 px-3 py-1.5 text-[13px] text-foreground hover:bg-muted/50 transition-colors text-left"
-                    >
-                      <Moon size={13} className="text-muted-foreground" />
-                      {t('sidebar.sleep', 'Sleep')}
-                    </button>
-                  )}
-                  {(!project.role || DELETE_ROLES.has(project.role)) && (
-                    <button
-                      onClick={() => handleDelete(project.id)}
-                      className={`w-full flex items-center gap-2 px-3 py-1.5 text-[13px] transition-colors text-left ${
-                        pendingDeleteId === project.id
-                          ? 'text-destructive bg-destructive/10'
-                          : 'text-foreground hover:bg-muted/50'
-                      }`}
-                    >
-                      <Trash2 size={13} className={pendingDeleteId === project.id ? 'text-destructive' : 'text-muted-foreground'} />
-                      {pendingDeleteId === project.id ? t('sidebar.confirmDelete') : t('common.delete')}
-                    </button>
-                  )}
-                </div>
-              )}
             </div>
           );
         })}
@@ -350,6 +281,79 @@ export function Sidebar({ onCollapse, onOpenSettings, onOpenAdmin }: SidebarProp
           <div className="px-2 py-2 text-[13px] text-muted-foreground">
             {t('sidebar.noProjectsMatch')}
           </div>
+        )}
+      </div>
+
+      <div
+        ref={menuRef}
+        id="project-menu"
+        popover="auto"
+        onToggle={(e) => {
+          if ((e as unknown as ToggleEvent).newState === 'closed') setPendingDeleteId(null);
+        }}
+        style={menuProject ? ({ positionAnchor: anchorName(menuProject.id) } as CSSProperties) : undefined}
+        className="anchored-menu min-w-35 bg-popover border border-border rounded-lg shadow-[var(--shadow-lg)] py-1"
+      >
+        {menuProject && (
+          <>
+            {(!menuProject.role || MANAGE_ROLES.has(menuProject.role)) && (
+              <button
+                onClick={() => startRename(menuProject)}
+                className="w-full flex items-center gap-2 px-3 py-1.5 text-[13px] text-foreground hover:bg-muted/50 transition-colors text-left"
+              >
+                <Pencil size={13} className="text-muted-foreground" />
+                {t('sidebar.rename')}
+              </button>
+            )}
+            {menuProject.summary && (
+              <button
+                onClick={() => handleShowSummary(menuProject)}
+                className="w-full flex items-center gap-2 px-3 py-1.5 text-[13px] text-foreground hover:bg-muted/50 transition-colors text-left"
+              >
+                <Info size={13} className="text-muted-foreground" />
+                {t('sidebar.summary')}
+              </button>
+            )}
+            {(!menuProject.role || MANAGE_ROLES.has(menuProject.role)) && (
+              <button
+                onClick={() => {
+                  closeMenu();
+                  setShareModal({ projectId: menuProject.id, projectName: menuProject.name, ownerUserId: menuProject.user_id });
+                }}
+                className="w-full flex items-center gap-2 px-3 py-1.5 text-[13px] text-foreground hover:bg-muted/50 transition-colors text-left"
+              >
+                <Share2 size={13} className="text-muted-foreground" />
+                {t('sharing.share', 'Share')}
+              </button>
+            )}
+            {isSpecialUser() && (
+              <button
+                onClick={async () => {
+                  closeMenu();
+                  try {
+                    await reapProject(menuProject.id);
+                  } catch { /* sandbox may already be reaped */ }
+                }}
+                className="w-full flex items-center gap-2 px-3 py-1.5 text-[13px] text-foreground hover:bg-muted/50 transition-colors text-left"
+              >
+                <Moon size={13} className="text-muted-foreground" />
+                {t('sidebar.sleep', 'Sleep')}
+              </button>
+            )}
+            {(!menuProject.role || DELETE_ROLES.has(menuProject.role)) && (
+              <button
+                onClick={() => handleDelete(menuProject.id)}
+                className={`w-full flex items-center gap-2 px-3 py-1.5 text-[13px] transition-colors text-left ${
+                  pendingDeleteId === menuProject.id
+                    ? 'text-destructive bg-destructive/10'
+                    : 'text-foreground hover:bg-muted/50'
+                }`}
+              >
+                <Trash2 size={13} className={pendingDeleteId === menuProject.id ? 'text-destructive' : 'text-muted-foreground'} />
+                {pendingDeleteId === menuProject.id ? t('sidebar.confirmDelete') : t('common.delete')}
+              </button>
+            )}
+          </>
         )}
       </div>
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -3,12 +3,11 @@ import { useTranslation } from 'react-i18next';
 import { useSessionStore } from '../../stores/session';
 import { useChatStore } from '../../stores/chat';
 import { useFilesStore } from '../../stores/files';
-import { Plus, Pin, PinOff, Loader2, MoreHorizontal, Trash2, Info, Settings, Pencil, Moon, Share2, Shield } from 'lucide-react';
+import { Plus, PanelLeftClose, Loader2, MoreHorizontal, Trash2, Info, Settings, Pencil, Moon, Share2, Shield } from 'lucide-react';
 import { FlowBrand } from '../ui/flow-logo';
 import { DELETE_ROLES, MANAGE_ROLES, type ProjectSummary } from '../../types';
 import { SummaryModal } from './SummaryModal';
 import { ShareModal } from '../sharing/ShareModal';
-import { AdminPanel } from '../admin/AdminPanel';
 import { reapProject } from '../../services/api';
 import { isSpecialUser } from '../../utils/easterEgg';
 import { pollFileTree } from '../../utils/pollFileTree';
@@ -16,11 +15,9 @@ import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 
 type SidebarProps = {
-  onCloseSidebar?: () => void;
-  isPinned?: boolean;
-  onPin?: () => void;
+  onCollapse?: () => void;
   onOpenSettings?: () => void;
-  onBusyChange?: (busy: boolean) => void;
+  onOpenAdmin?: () => void;
 };
 
 // Stable color per project based on name hash
@@ -47,7 +44,7 @@ function getInitials(name: string) {
   return name.slice(0, 2).toUpperCase();
 }
 
-export function Sidebar({ onCloseSidebar, isPinned, onPin, onOpenSettings, onBusyChange }: SidebarProps) {
+export function Sidebar({ onCollapse, onOpenSettings, onOpenAdmin }: SidebarProps) {
   const { t } = useTranslation();
   const { projects, currentProject, setCurrentProject, createProject, deleteProject, renameProject, isCreating, userStatus } = useSessionStore();
   const { clearMessages, loadHistory } = useChatStore();
@@ -56,7 +53,6 @@ export function Sidebar({ onCloseSidebar, isPinned, onPin, onOpenSettings, onBus
   const [showInput, setShowInput] = useState(false);
   const [summaryModal, setSummaryModal] = useState<{ projectName: string; summary: ProjectSummary } | null>(null);
   const [shareModal, setShareModal] = useState<{ projectId: string; projectName: string; ownerUserId?: string } | null>(null);
-  const [showAdminPanel, setShowAdminPanel] = useState(false);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
   const [renamingId, setRenamingId] = useState<string | null>(null);
@@ -64,12 +60,6 @@ export function Sidebar({ onCloseSidebar, isPinned, onPin, onOpenSettings, onBus
   const menuRef = useRef<HTMLDivElement>(null);
 
   const canCreate = userStatus?.is_platform_user || userStatus?.is_admin;
-
-  // Notify parent when user is busy with an action
-  useEffect(() => {
-    const isBusy = showInput || !!menuOpenId || !!renamingId || !!pendingDeleteId;
-    onBusyChange?.(isBusy);
-  }, [showInput, menuOpenId, renamingId, pendingDeleteId, onBusyChange]);
 
   useEffect(() => {
     if (!menuOpenId) return;
@@ -162,14 +152,9 @@ export function Sidebar({ onCloseSidebar, isPinned, onPin, onOpenSettings, onBus
       <div className="flex items-center justify-between px-3 py-3">
         <FlowBrand size="sm" />
         <div className="flex items-center gap-0.5">
-          {onPin && !isPinned && (
-            <Button variant="ghost" size="icon-sm" onClick={onPin} title={t('sidebar.pinSidebar')}>
-              <Pin size={14} className="text-primary/60" />
-            </Button>
-          )}
-          {isPinned && onCloseSidebar && (
-            <Button variant="ghost" size="icon-sm" onClick={onCloseSidebar} title={t('sidebar.unpinSidebar')}>
-              <PinOff size={14} className="text-primary/60" />
+          {onCollapse && (
+            <Button variant="ghost" size="icon-sm" onClick={onCollapse} title={t('sidebar.collapseSidebar')}>
+              <PanelLeftClose size={14} className="text-primary/60" />
             </Button>
           )}
         </div>
@@ -342,7 +327,7 @@ export function Sidebar({ onCloseSidebar, isPinned, onPin, onOpenSettings, onBus
       {/* Bottom: Settings + Admin */}
       <div className="border-t border-border px-3 py-2 space-y-0.5">
         {userStatus?.is_admin && (
-          <Button variant="ghost" size="sm" onClick={() => setShowAdminPanel(true)} className="w-full justify-start gap-2 text-muted-foreground hover:text-foreground">
+          <Button variant="ghost" size="sm" onClick={onOpenAdmin} className="w-full justify-start gap-2 text-muted-foreground hover:text-foreground">
             <Shield size={14} className="text-warning/70" />
             <span className="text-[13px]">{t('admin.title', 'Platform Users')}</span>
           </Button>
@@ -368,10 +353,6 @@ export function Sidebar({ onCloseSidebar, isPinned, onPin, onOpenSettings, onBus
           ownerUserId={shareModal.ownerUserId}
           onClose={() => setShareModal(null)}
         />
-      )}
-
-      {showAdminPanel && (
-        <AdminPanel onClose={() => setShowAdminPanel(false)} />
       )}
     </div>
   );

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useSessionStore } from '../../stores/session';
 import { useChatStore } from '../../stores/chat';
 import { useFilesStore } from '../../stores/files';
-import { Plus, PanelLeftClose, Loader2, MoreHorizontal, Trash2, Info, Settings, Pencil, Moon, Share2, Shield } from 'lucide-react';
+import { Plus, PanelLeftClose, Loader2, MoreHorizontal, Trash2, Info, Settings, Pencil, Moon, Share2, Shield, Search } from 'lucide-react';
 import { FlowBrand } from '../ui/flow-logo';
 import { DELETE_ROLES, MANAGE_ROLES, type ProjectSummary } from '../../types';
 import { SummaryModal } from './SummaryModal';
@@ -49,6 +49,7 @@ export function Sidebar({ onCollapse, onOpenSettings, onOpenAdmin }: SidebarProp
   const { projects, currentProject, setCurrentProject, createProject, deleteProject, renameProject, isCreating, userStatus } = useSessionStore();
   const { clearMessages, loadHistory } = useChatStore();
   const { loadFileTree, reset: resetFiles } = useFilesStore();
+  const [searchQuery, setSearchQuery] = useState('');
   const [newName, setNewName] = useState('');
   const [showInput, setShowInput] = useState(false);
   const [summaryModal, setSummaryModal] = useState<{ projectName: string; summary: ProjectSummary } | null>(null);
@@ -146,6 +147,12 @@ export function Sidebar({ onCollapse, onOpenSettings, onOpenAdmin }: SidebarProp
     }
   };
 
+  const canSearchProjects = projects.length > 10;
+  const normalizedSearch = canSearchProjects ? searchQuery.trim().toLowerCase() : '';
+  const visibleProjects = normalizedSearch
+    ? projects.filter((p) => p.name.toLowerCase().includes(normalizedSearch))
+    : projects;
+
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
@@ -200,9 +207,26 @@ export function Sidebar({ onCollapse, onOpenSettings, onOpenAdmin }: SidebarProp
         </div>
       )}
 
+      {/* Project search */}
+      {canSearchProjects && (
+        <div className="px-3 mb-2">
+          <div className="flex items-center gap-2 px-3 py-2 bg-background border border-border rounded-lg">
+            <Search size={14} className="shrink-0 text-muted-foreground" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder={t('sidebar.searchPlaceholder')}
+              data-testid="project-search"
+              className="flex-1 text-[13px] bg-transparent"
+            />
+          </div>
+        </div>
+      )}
+
       {/* Project list */}
       <div className="flex-1 overflow-auto px-2">
-        {projects.map((project) => {
+        {visibleProjects.map((project) => {
           const isActive = currentProject?.id === project.id;
           const isMenuOpen = menuOpenId === project.id;
           const colorClass = getProjectColor(project.name);
@@ -322,6 +346,11 @@ export function Sidebar({ onCollapse, onOpenSettings, onOpenAdmin }: SidebarProp
             </div>
           );
         })}
+        {normalizedSearch && visibleProjects.length === 0 && (
+          <div className="px-2 py-2 text-[13px] text-muted-foreground">
+            {t('sidebar.noProjectsMatch')}
+          </div>
+        )}
       </div>
 
       {/* Bottom: Settings + Admin */}

--- a/frontend/src/components/preview/Preview.tsx
+++ b/frontend/src/components/preview/Preview.tsx
@@ -17,7 +17,6 @@ export function Preview() {
   const saveVersion = useFilesStore((s) => s.saveVersion);
   
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  const [refreshKey, setRefreshKey] = useState(0);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -29,25 +28,28 @@ export function Preview() {
   useEffect(() => {
     if (!projectId) {
       setPreviewUrl(null);
+      setLoading(false);
       return;
     }
     setLoading(true);
     credentialsStore.ensureCookie();
-    const url = `/api/preview/${projectId}/proxy/`;
-    setPreviewUrl(url);
-    setLoading(false);
-    console.debug('[Preview] refresh — reason: project changed', { projectId, refreshKey });
-  }, [projectId, refreshKey]);
+    setPreviewUrl(`/api/preview/${projectId}/proxy/`);
+  }, [projectId]);
 
   const clearConsole = useConsoleStore((s) => s.clear);
 
-  // Auto-refresh preview when files are saved (by user or AI).
-  // Debounce to avoid rapid refreshes during bulk writes.
+  const reloadPreview = useCallback((reason: string) => {
+    const frame = iframeRef.current?.contentWindow;
+    if (!frame) return;
+    console.debug(`[Preview] refresh — reason: ${reason}`);
+    clearConsole();
+    setLoading(true);
+    frame.location.reload();
+  }, [clearConsole]);
+
   const saveVersionRef = useRef(saveVersion);
   const debouncedRefresh = useDebouncedCallback(() => {
-    console.debug('[Preview] refresh — reason: files saved');
-    clearConsole();
-    setRefreshKey((k) => k + 1);
+    reloadPreview('files saved');
   }, 2000, { maxWait: 8000 });
   useEffect(() => {
     if (saveVersion === saveVersionRef.current) return;
@@ -55,11 +57,7 @@ export function Preview() {
     debouncedRefresh();
   }, [saveVersion, debouncedRefresh]);
 
-  const handleRefresh = () => {
-    console.debug('[Preview] refresh — reason: manual');
-    clearConsole();
-    setRefreshKey((k) => k + 1);
-  };
+  const handleRefresh = () => reloadPreview('manual');
 
   const handlePublish = useCallback(() => {
     if (projectId) {
@@ -123,19 +121,27 @@ export function Preview() {
 
       {/* iframe */}
       {previewUrl ? (
-        <iframe
-          ref={iframeRef}
-          key={refreshKey}
-          src={previewUrl}
-          sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
-          className="flex-1 w-full border-none"
-          style={{ background: 'var(--preview-bg)' }}
-          title={t('preview.title')}
-          data-testid="preview-iframe"
-        />
+        <div className="relative flex-1">
+          <iframe
+            ref={iframeRef}
+            src={previewUrl}
+            onLoad={() => setLoading(false)}
+            sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
+            className="absolute inset-0 w-full h-full border-none"
+            style={{ background: 'var(--preview-bg)' }}
+            title={t('preview.title')}
+            data-testid="preview-iframe"
+          />
+          <div
+            className={`pointer-events-none absolute inset-0 flex items-center justify-center gap-2 text-muted-foreground text-sm bg-[var(--preview-bg)]/85 transition-opacity duration-200 ${loading ? 'opacity-100' : 'opacity-0'}`}
+          >
+            <RefreshCw size={16} className="animate-spin text-primary/70" />
+            {t('preview.loading')}
+          </div>
+        </div>
       ) : (
         <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
-          {loading ? t('preview.loading') : t('preview.noPreviewAvailable')}
+          {t('preview.noPreviewAvailable')}
         </div>
       )}
     </div>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -31,7 +31,9 @@
     "rename": "Rename",
     "summary": "Summary",
     "sleep": "Sleep",
-    "confirmDelete": "Confirm delete?"
+    "confirmDelete": "Confirm delete?",
+    "searchPlaceholder": "Search projects...",
+    "noProjectsMatch": "No projects match"
   },
   "settings": {
     "title": "Settings",
@@ -172,7 +174,8 @@
     },
     "dataSource": {
       "removeDataSource": "Remove data source",
-      "searchPlaceholder": "Search data sources (optional)"
+      "searchPlaceholder": "Search data sources (optional)",
+      "usedInProject": "Used in this project"
     }
   },
   "sharing": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -137,6 +137,8 @@
     "send": "send",
     "newLine": "new line",
     "scrollToBottom": "Scroll to bottom",
+    "today": "Today",
+    "yesterday": "Yesterday",
     "placeholder": {
       "selectProject": "Select a project first",
       "reviewPlan": "Review the plan above, then accept or modify",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -24,8 +24,7 @@
     "noAccessMessage": "You don't have access to create projects yet. Ask your administrator for an invitation."
   },
   "sidebar": {
-    "pinSidebar": "Pin sidebar open",
-    "unpinSidebar": "Unpin sidebar",
+    "collapseSidebar": "Collapse sidebar",
     "expandSidebar": "Expand sidebar",
     "newProject": "New Project",
     "scaffolding": "Scaffolding project...",

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -24,8 +24,7 @@
     "noAccessMessage": "אין לך הרשאה ליצור פרויקטים. פנה למנהל המערכת לקבלת הזמנה."
   },
   "sidebar": {
-    "pinSidebar": "נעץ סרגל צד",
-    "unpinSidebar": "בטל נעיצת סרגל צד",
+    "collapseSidebar": "כווץ סרגל צד",
     "expandSidebar": "הרחב סרגל צד",
     "newProject": "פרויקט חדש",
     "scaffolding": "מכין פרויקט...",

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -137,6 +137,8 @@
     "send": "שלח",
     "newLine": "שורה חדשה",
     "scrollToBottom": "גלול לתחתית",
+    "today": "היום",
+    "yesterday": "אתמול",
     "placeholder": {
       "selectProject": "בחר פרויקט תחילה",
       "reviewPlan": "בדוק את התוכנית למעלה, ולאחר מכן אשר או שנה",

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -31,7 +31,9 @@
     "rename": "שנה שם",
     "summary": "סיכום",
     "sleep": "השהה",
-    "confirmDelete": "אשר מחיקה?"
+    "confirmDelete": "אשר מחיקה?",
+    "searchPlaceholder": "חפש פרויקטים...",
+    "noProjectsMatch": "אין פרויקטים תואמים"
   },
   "settings": {
     "title": "הגדרות",
@@ -172,7 +174,8 @@
     },
     "dataSource": {
       "removeDataSource": "הסר מקור נתונים",
-      "searchPlaceholder": "חפש מקורות נתונים (אופציונלי)"
+      "searchPlaceholder": "חפש מקורות נתונים (אופציונלי)",
+      "usedInProject": "שימש בפרויקט זה"
     }
   },
   "sharing": {

--- a/frontend/src/stores/chatHandlers.ts
+++ b/frontend/src/stores/chatHandlers.ts
@@ -139,7 +139,7 @@ export function createFixErrorHandler(
   cleanup: () => void,
 ) {
   return (msg: WSMessage) => {
-    getTimestamp(msg as { _ts?: string });
+    getTimestamp(msg);
     switch (msg.type) {
       case 'phase':
         set({ agentPhase: msg.phase });
@@ -205,7 +205,7 @@ export function createSendMessageHandler(
 ) {
   _skipMessages = options?.replay ?? false;
   return (msg: WSMessage) => {
-    getTimestamp(msg as { _ts?: string });
+    getTimestamp(msg);
     switch (msg.type) {
       case 'phase':
         handlePhaseChange(msg, set, get);

--- a/frontend/src/stores/chatHandlers.ts
+++ b/frontend/src/stores/chatHandlers.ts
@@ -2,6 +2,7 @@ import type { WSMessage, Message, FollowUpStep, AgentPhase, ProjectSummary } fro
 import { throttle } from '../utils/debounce';
 import { useFilesStore } from './files';
 import { useSessionStore } from './session';
+import { useErrorStore } from './errors';
 import {
   requestPermissionIfNeeded,
   notifyAgentNeedsAttention,
@@ -77,8 +78,7 @@ function handleFileUpdate(msg: { path: string; content: string }, set: SetState)
   if (filesStore.openFiles.has(msg.path)) {
     filesStore.updateFileContent(msg.path, msg.content);
   }
-  // New files on disk (e.g. fix pass) — keep explorer in sync before action_complete.
-  refreshFileTreeAfterAgentWrite();
+  if (!_skipMessages) _treeRefresh();
 }
 
 function handleText(msg: { content: string }, set: SetState) {
@@ -186,6 +186,7 @@ export function createFixErrorHandler(
         }
         if (!_skipMessages) {
           notifyBuildComplete(useSessionStore.getState().currentProject?.name);
+          useErrorStore.getState().clearErrors();
         }
         cleanup();
         refreshFileTreeAfterAgentWrite();
@@ -501,6 +502,7 @@ function handleActionComplete(set: SetState, get: GetState, cleanup: () => void)
   }));
   if (!_skipMessages) {
     notifyBuildComplete(useSessionStore.getState().currentProject?.name);
+    useErrorStore.getState().clearErrors();
   }
   cleanup();
   refreshFileTreeAfterAgentWrite();

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -164,7 +164,7 @@ export interface FollowUpStep {
   iteration: number;
 }
 
-export type WSMessage =
+export type WSMessage = { _ts?: string } & (
   | { type: 'message'; content: string; model?: string; dataSourceIds?: number[] }
   | { type: 'text'; content: string }
   | { type: 'file'; path: string; content: string }
@@ -186,4 +186,5 @@ export type WSMessage =
   | { type: 'followup_step'; tool: string; args: Record<string, string>; status: string; result_preview?: string; iteration: number }
   | { type: 'file_diffs'; diffs: FileDiff[] }
   | { type: 'user_message'; content: string; data_sources?: { id: number; name: string }[]; error_fix_request?: { errorMessage: string; errorFile?: string; errorLine?: number; errorStack?: string } }
-  | { type: 'plan_accepted'; overview: PlanOverview };
+  | { type: 'plan_accepted'; overview: PlanOverview }
+);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -99,7 +99,7 @@ export interface AIModel {
 export interface DataSourceSearchResult {
   id: number;
   name: string;
-  description: string | null;
+  description?: string | null;
 }
 
 // Agent types

--- a/frontend/src/utils/__tests__/formatTime.test.ts
+++ b/frontend/src/utils/__tests__/formatTime.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TFunction } from 'i18next';
+import { formatClock, formatDayDivider, sameDay } from '../formatTime';
+
+const t = ((_key: string, fallback: string) => fallback) as unknown as TFunction;
+
+const at = (h: number, m: number, dayOffset = 0) => {
+  const d = new Date(2026, 6, 20, h, m, 0, 0);
+  d.setDate(d.getDate() + dayOffset);
+  return d.getTime();
+};
+
+beforeEach(() => vi.setSystemTime(new Date(2026, 6, 20, 12, 0, 0)));
+afterEach(() => vi.useRealTimers());
+
+describe('formatClock', () => {
+  it('formats 24-hour clock time', () => {
+    expect(formatClock(at(14, 32), 'en')).toBe('14:32');
+    expect(formatClock(at(9, 5), 'he')).toBe('09:05');
+  });
+});
+
+describe('sameDay', () => {
+  it('is true within a day and false across midnight', () => {
+    expect(sameDay(at(1, 0), at(23, 59))).toBe(true);
+    expect(sameDay(at(23, 59), at(0, 1, 1))).toBe(false);
+  });
+});
+
+describe('formatDayDivider', () => {
+  it('labels today and yesterday', () => {
+    expect(formatDayDivider(at(10, 0), 'en', t)).toBe('Today');
+    expect(formatDayDivider(at(10, 0, -1), 'en', t)).toBe('Yesterday');
+  });
+
+  it('falls back to a full date for older days', () => {
+    expect(formatDayDivider(at(10, 0, -5), 'en', t)).not.toMatch(/Today|Yesterday/);
+  });
+});

--- a/frontend/src/utils/formatTime.ts
+++ b/frontend/src/utils/formatTime.ts
@@ -1,0 +1,22 @@
+import { format, isSameDay, isToday, isYesterday } from 'date-fns';
+import { enUS, he } from 'date-fns/locale';
+import type { Locale } from 'date-fns';
+import type { TFunction } from 'i18next';
+
+function resolveLocale(lang: string): Locale {
+  return lang.startsWith('he') ? he : enUS;
+}
+
+export function formatClock(ts: number, lang: string): string {
+  return format(ts, 'HH:mm', { locale: resolveLocale(lang) });
+}
+
+export function sameDay(a: number, b: number): boolean {
+  return isSameDay(a, b);
+}
+
+export function formatDayDivider(ts: number, lang: string, t: TFunction): string {
+  if (isToday(ts)) return t('chat.today', 'Today');
+  if (isYesterday(ts)) return t('chat.yesterday', 'Yesterday');
+  return format(ts, 'PPP', { locale: resolveLocale(lang) });
+}


### PR DESCRIPTION
A batch of UI fixes and two small features for the chat/sidebar/preview shell.

## Features

### Chat message timestamps + sticky day dividers  (6042c39)
- Hover-reveal `HH:mm` under each message bubble and on the fix-error card
  (locale-aware, date-fns).
- Messages grouped by day with a WhatsApp-style sticky "Today / Yesterday /
  <date>" pill that pins while scrolling and hands off at each day boundary.
- **Root-cause fix:** live WebSocket events carried no timestamp (only replayed
  history did), so live messages could inherit a stale historical time.
  `emit_event` now stamps `_ts` on the payload at emit time; no migration.
- Adds `date-fns`; new `utils/formatTime.ts` (+ tests).

### Sidebar project search + suggested data sources  (b71ff16)
- Search box to filter projects in the sidebar.
- Suggest previously-used data sources in the data-source selector.

## Fixes

### UI quirks: autoscroll, error toasts, preview flicker, sidebar  (1a93c05)
- Chat autoscroll behavior (pin-to-bottom / stick logic in `ChatPanel`).
- Error toast handling (`ErrorToast`, `ErrorFixRequestCard`).
- Preview flicker (`Preview.tsx`).
- Sidebar + mobile layout adjustments (`AppShell`, `Sidebar`, `MobileLayout`).

### Pop hover menu in projects sidebar  (5a3da01)
- Sidebar project hover menu popover (`Sidebar.tsx`, `App.css`).

### E2E test fixes  (11bf815)
- Repaired `happy-path` and `project-lifecycle` specs; small `AppShell` tweak.

New changes
<img width="1602" height="917" alt="Screenshot 2026-07-26 133131" src="https://github.com/user-attachments/assets/6d61e0d0-1e43-4d9f-8554-7c6bfd93dd43" />

More new changes
<img width="1917" height="968" alt="Screenshot 2026-07-26 133713" src="https://github.com/user-attachments/assets/7096637d-4d5a-4de7-98e1-70985b553c5d" />

The new change in the dropdown 
<img width="1918" height="907" alt="Screenshot 2026-07-26 133946" src="https://github.com/user-attachments/assets/85066a14-adcb-49af-bae8-89609b12191a" />


Old state - the new staff isn't marked because they didn't exisits :)
<img width="1917" height="928" alt="Screenshot 2026-07-26 162611" src="https://github.com/user-attachments/assets/c71e6d64-4e23-42dc-9fde-eb3e840b6ece" />
