### PR TITLE
Migrate observability from Langfuse to Opik

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,12 +205,10 @@ Edit `AIB_AI_MODEL` and `AIB_AI_BASE_URL` in `backend/.env` to switch providers:
 
 ## Observability (optional)
 
-Set the following in `backend/.env` to enable Langfuse tracing:
+Set the following in `backend/.env` to enable Opik tracing:
 
 ```env
-AIB_LANGFUSE_PUBLIC_KEY=pk-lf-...
-AIB_LANGFUSE_SECRET_KEY=sk-lf-...
-AIB_LANGFUSE_HOST=https://cloud.langfuse.com
+AIB_OPIK_API_KEY=...
+AIB_OPIK_WORKSPACE=your-workspace
+AIB_OPIK_PROJECT_NAME=flow44
 ```
-
-A self-hosted Langfuse stack is available under `mocks/langfuse/docker-compose.yaml`.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -44,11 +44,12 @@ AIB_AI_API_KEY=default
 # Logging (optional — write JSON logs to a file in addition to console)
 # AIB_LOG_FILE_PATH=app.log
 
-# Langfuse (optional — for observability/tracing)
-# AIB_LANGFUSE_PUBLIC_KEY=pk-lf-...
-# AIB_LANGFUSE_SECRET_KEY=sk-lf-...
-# AIB_LANGFUSE_HOST=https://cloud.langfuse.com
-# AIB_LANGFUSE_TRACING_ENVIRONMENT=development
+# Opik (optional — for observability/tracing)
+# AIB_OPIK_API_KEY=...
+# AIB_OPIK_WORKSPACE=your-workspace
+# AIB_OPIK_PROJECT_NAME=flow44
+# For self-hosted Opik, also set:
+# AIB_OPIK_URL_OVERRIDE=http://localhost:5173/api
 
 # Authentication / JWT Validation
 # Required: JWT public key (or HMAC secret) used to verify token signatures.

--- a/backend/benchmarks/src/runner.py
+++ b/backend/benchmarks/src/runner.py
@@ -256,24 +256,16 @@ async def _take_screenshot(html_path: Path, output_path: Path) -> None:
 
 
 def _init_env() -> None:
-    """Initialize Langfuse + litellm callbacks (same as main.py lifespan)."""
-    import os  # noqa: PLC0415
-
+    """Initialize Opik + litellm callbacks (same as main.py lifespan)."""
     import litellm as _litellm  # noqa: PLC0415
+    from litellm.integrations.opik.opik import OpikLogger  # noqa: PLC0415
 
-    if settings.LANGFUSE_PUBLIC_KEY:
-        os.environ["LANGFUSE_PUBLIC_KEY"] = settings.LANGFUSE_PUBLIC_KEY
-        os.environ["LANGFUSE_SECRET_KEY"] = settings.LANGFUSE_SECRET_KEY
-        os.environ["LANGFUSE_HOST"] = settings.LANGFUSE_HOST
-
-        from langfuse import Langfuse  # noqa: PLC0415
-
-        Langfuse()
-        _litellm.success_callback = ["langfuse"]
-        _litellm.failure_callback = ["langfuse"]
-        typer.echo(f"Langfuse: enabled ({settings.LANGFUSE_HOST})")
+    if settings.OPIK_API_KEY:
+        # Credentials already in os.environ via OpikSettings.model_post_init
+        _litellm.callbacks = [OpikLogger()]
+        typer.echo(f"Opik: enabled (project={settings.OPIK_PROJECT_NAME})")
     else:
-        typer.echo("Langfuse: disabled")
+        typer.echo("Opik: disabled")
 
 
 async def _run_all(config: dict[str, Any]) -> None:

--- a/backend/benchmarks/src/runner.py
+++ b/backend/benchmarks/src/runner.py
@@ -258,11 +258,12 @@ async def _take_screenshot(html_path: Path, output_path: Path) -> None:
 def _init_env() -> None:
     """Initialize Opik + litellm callbacks (same as main.py lifespan)."""
     import litellm as _litellm  # noqa: PLC0415
-    from litellm.integrations.opik.opik import OpikLogger  # noqa: PLC0415
+
+    from flow44.ai.core.opik_failure_logger import FailureAwareOpikLogger  # noqa: PLC0415
 
     if settings.OPIK_API_KEY:
         # Credentials already in os.environ via OpikSettings.model_post_init
-        _litellm.callbacks = [OpikLogger()]
+        _litellm.callbacks = [FailureAwareOpikLogger()]
         typer.echo(f"Opik: enabled (project={settings.OPIK_PROJECT_NAME})")
     else:
         typer.echo("Opik: disabled")

--- a/backend/mypy.toml
+++ b/backend/mypy.toml
@@ -59,7 +59,6 @@ warn_untyped_fields = true
 ###### MISSING IMPORTS  #####
 [[tool.mypy.overrides]]
 module = [
-    "langfuse.*",
     "winpty",
     "winpty.*",
 ]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,8 +14,8 @@ dependencies = [
     "greenlet>=3.3.2",
     "httpx>=0.28.0",
     "jinja2>=3.1.0",
-    "langfuse==2.59.7",     # using langfuse 2.59.7 compatible with litellm
-    "litellm>=1.55.10,<1.82.3",
+    "litellm>=1.55.10",
+    "opik>=2.1.32",
     "pydantic-settings>=2.7.1",
     "pyjwt>=2.12.1",
     "python-json-logger>=4.1.0",

--- a/backend/src/flow44/ai/agents/_base.py
+++ b/backend/src/flow44/ai/agents/_base.py
@@ -1,6 +1,8 @@
+import traceback as traceback_module
 from typing import Any
 
-from langfuse.decorators import langfuse_context
+from opik import opik_context
+from opik.types import ErrorInfoDict
 
 from flow44.db.events import emit_event
 from flow44.sandbox.main import PnpmSandbox
@@ -25,22 +27,65 @@ class BaseAgent:
         self._trace_id = trace_id
 
     def _setup_trace(self, tags: list[str]) -> None:
-        self._trace_id = langfuse_context.get_current_trace_id()
-        langfuse_context.update_current_trace(
-            session_id=self.project_id,
-            user_id=self._user_id,
-            metadata={"model": self.model or "default"},
-            tags=tags,
+        trace_data = opik_context.get_current_trace_data()
+        self._trace_id = trace_data.id if trace_data else None
+        opik_context.update_current_trace(
+            thread_id=self.project_id,
+            metadata={"model": self.model or "default", "user_id": self._user_id},
+            tags=[*tags, f"project:{self.project_id}"],
         )
 
     async def emit(self, event: dict[str, Any]) -> None:
         await emit_event(self.project_id, event)
 
-    def _llm_metadata(self, generation_name: str) -> dict[str, Any]:
-        trace_id = self._trace_id or langfuse_context.get_current_trace_id()
-        observation_id = langfuse_context.get_current_observation_id()
-        return {
-            "existing_trace_id": trace_id,
-            "parent_observation_id": observation_id,
+    def _set_trace_output(self, output: dict[str, Any]) -> None:
+        """Record a summary on the top-level trace so its outcome is visible without opening spans."""
+        if opik_context.get_current_trace_data() is not None:
+            opik_context.update_current_trace(output=output)
+
+    def _record_span_error(self, exc: Exception) -> None:
+        """Mark the current @track-decorated span as failed, so a logged-and-swallowed
+        exception still surfaces as an error in the Opik UI. No-op outside a tracked span
+        (e.g. when a step is unit-tested directly, bypassing `run()`)."""
+        if opik_context.get_current_span_data() is not None:
+            opik_context.update_current_span(error_info=self._error_info(exc))
+
+    @staticmethod
+    def _error_info(exc: Exception) -> ErrorInfoDict:
+        """Build Opik error info from a caught exception, so a logged-and-swallowed
+        failure still surfaces as an error on the span in the Opik UI."""
+        info: ErrorInfoDict = {
+            "exception_type": type(exc).__name__,
+            "traceback": "".join(traceback_module.format_exception(exc)),
+        }
+        message = str(exc)
+        if message:
+            info["message"] = message
+        return info
+
+    def _llm_metadata(
+        self,
+        generation_name: str,
+        parent_span_id: str | None = None,
+        extra_metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Build Opik metadata for an LLM call.
+
+        `parent_span_id` lets callers nest under a manually-created Opik span (e.g. a step
+        span created via `Opik().span(...)`) — those aren't visible to `opik_context`, which
+        only tracks spans created by the `@track` decorator.
+
+        `extra_metadata` is merged into the span's top-level metadata (e.g. `available_tools`,
+        `tool_calls`) — anything under `metadata["opik"]` besides `current_span_data` gets
+        promoted straight into the span, same as `generation_name` already is.
+        """
+        span_data = opik_context.get_current_span_data()
+        trace_id = self._trace_id or (span_data.trace_id if span_data else None)
+        resolved_parent_span_id = parent_span_id or (span_data.id if span_data else None)
+        opik_meta: dict[str, Any] = {
+            "current_span_data": {"trace_id": trace_id, "id": resolved_parent_span_id},
             "generation_name": generation_name,
         }
+        if extra_metadata:
+            opik_meta.update(extra_metadata)
+        return {"opik": opik_meta}

--- a/backend/src/flow44/ai/agents/_base.py
+++ b/backend/src/flow44/ai/agents/_base.py
@@ -1,3 +1,4 @@
+import logging
 import traceback as traceback_module
 from typing import Any
 
@@ -6,6 +7,18 @@ from opik.types import ErrorInfoDict
 
 from flow44.db.events import emit_event
 from flow44.sandbox.main import PnpmSandbox
+
+logger = logging.getLogger(__name__)
+
+
+class _NullSpan:
+    """No-op stand-in for an Opik span, used when span creation itself fails (e.g. Opik
+    unreachable) so the caller's actual work can still proceed uninterrupted."""
+
+    id: str | None = None
+
+    def end(self, **_kwargs: Any) -> None:
+        pass
 
 
 class BaseAgent:
@@ -42,6 +55,17 @@ class BaseAgent:
         """Record a summary on the top-level trace so its outcome is visible without opening spans."""
         if opik_context.get_current_trace_data() is not None:
             opik_context.update_current_trace(output=output)
+
+    @staticmethod
+    def _safe_span(opik_client: Any, **kwargs: Any) -> Any:
+        """Create a manual Opik span, tolerating failure in the creation call itself (e.g. Opik
+        unreachable) — returns a no-op span instead of raising, so the actual agent work isn't
+        aborted by an observability outage."""
+        try:
+            return opik_client.span(**kwargs)
+        except Exception:
+            logger.exception("Failed to create Opik span %r", kwargs.get("name"))
+            return _NullSpan()
 
     def _record_span_error(self, exc: Exception) -> None:
         """Mark the current @track-decorated span as failed, so a logged-and-swallowed

--- a/backend/src/flow44/ai/agents/_base.py
+++ b/backend/src/flow44/ai/agents/_base.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from flow44.ai.core.opik_failure_logger import llm_metadata, set_trace_output, setup_trace
+from flow44.ai.core.opik_failure_logger import llm_metadata, set_trace_input, set_trace_output, setup_trace
 from flow44.db.events import emit_event
 from flow44.sandbox.main import PnpmSandbox
 
@@ -28,6 +28,9 @@ class BaseAgent:
 
     async def emit(self, event: dict[str, Any]) -> None:
         await emit_event(self.project_id, event)
+
+    def _set_trace_input(self, input_data: dict[str, Any]) -> None:
+        set_trace_input(input_data)
 
     def _set_trace_output(self, output: dict[str, Any]) -> None:
         set_trace_output(output)

--- a/backend/src/flow44/ai/agents/_base.py
+++ b/backend/src/flow44/ai/agents/_base.py
@@ -1,24 +1,8 @@
-import logging
-import traceback as traceback_module
 from typing import Any
 
-from opik import opik_context
-from opik.types import ErrorInfoDict
-
+from flow44.ai.core.opik_failure_logger import llm_metadata, set_trace_output, setup_trace
 from flow44.db.events import emit_event
 from flow44.sandbox.main import PnpmSandbox
-
-logger = logging.getLogger(__name__)
-
-
-class _NullSpan:
-    """No-op stand-in for an Opik span, used when span creation itself fails (e.g. Opik
-    unreachable) so the caller's actual work can still proceed uninterrupted."""
-
-    id: str | None = None
-
-    def end(self, **_kwargs: Any) -> None:
-        pass
 
 
 class BaseAgent:
@@ -40,52 +24,13 @@ class BaseAgent:
         self._trace_id = trace_id
 
     def _setup_trace(self, tags: list[str]) -> None:
-        trace_data = opik_context.get_current_trace_data()
-        self._trace_id = trace_data.id if trace_data else None
-        opik_context.update_current_trace(
-            thread_id=self.project_id,
-            metadata={"model": self.model or "default", "user_id": self._user_id},
-            tags=[*tags, f"project:{self.project_id}"],
-        )
+        self._trace_id = setup_trace(self.project_id, self._user_id, self.model, tags)
 
     async def emit(self, event: dict[str, Any]) -> None:
         await emit_event(self.project_id, event)
 
     def _set_trace_output(self, output: dict[str, Any]) -> None:
-        """Record a summary on the top-level trace so its outcome is visible without opening spans."""
-        if opik_context.get_current_trace_data() is not None:
-            opik_context.update_current_trace(output=output)
-
-    @staticmethod
-    def _safe_span(opik_client: Any, **kwargs: Any) -> Any:
-        """Create a manual Opik span, tolerating failure in the creation call itself (e.g. Opik
-        unreachable) — returns a no-op span instead of raising, so the actual agent work isn't
-        aborted by an observability outage."""
-        try:
-            return opik_client.span(**kwargs)
-        except Exception:
-            logger.exception("Failed to create Opik span %r", kwargs.get("name"))
-            return _NullSpan()
-
-    def _record_span_error(self, exc: Exception) -> None:
-        """Mark the current @track-decorated span as failed, so a logged-and-swallowed
-        exception still surfaces as an error in the Opik UI. No-op outside a tracked span
-        (e.g. when a step is unit-tested directly, bypassing `run()`)."""
-        if opik_context.get_current_span_data() is not None:
-            opik_context.update_current_span(error_info=self._error_info(exc))
-
-    @staticmethod
-    def _error_info(exc: Exception) -> ErrorInfoDict:
-        """Build Opik error info from a caught exception, so a logged-and-swallowed
-        failure still surfaces as an error on the span in the Opik UI."""
-        info: ErrorInfoDict = {
-            "exception_type": type(exc).__name__,
-            "traceback": "".join(traceback_module.format_exception(exc)),
-        }
-        message = str(exc)
-        if message:
-            info["message"] = message
-        return info
+        set_trace_output(output)
 
     def _llm_metadata(
         self,
@@ -93,23 +38,4 @@ class BaseAgent:
         parent_span_id: str | None = None,
         extra_metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Build Opik metadata for an LLM call.
-
-        `parent_span_id` lets callers nest under a manually-created Opik span (e.g. a step
-        span created via `Opik().span(...)`) — those aren't visible to `opik_context`, which
-        only tracks spans created by the `@track` decorator.
-
-        `extra_metadata` is merged into the span's top-level metadata (e.g. `available_tools`,
-        `tool_calls`) — anything under `metadata["opik"]` besides `current_span_data` gets
-        promoted straight into the span, same as `generation_name` already is.
-        """
-        span_data = opik_context.get_current_span_data()
-        trace_id = self._trace_id or (span_data.trace_id if span_data else None)
-        resolved_parent_span_id = parent_span_id or (span_data.id if span_data else None)
-        opik_meta: dict[str, Any] = {
-            "current_span_data": {"trace_id": trace_id, "id": resolved_parent_span_id},
-            "generation_name": generation_name,
-        }
-        if extra_metadata:
-            opik_meta.update(extra_metadata)
-        return {"opik": opik_meta}
+        return llm_metadata(self._trace_id, generation_name, parent_span_id, extra_metadata)

--- a/backend/src/flow44/ai/agents/execute/agent.py
+++ b/backend/src/flow44/ai/agents/execute/agent.py
@@ -17,7 +17,7 @@ from flow44.ai.agents.execute.prompts import (
 )
 from flow44.ai.core.flow import Flow
 from flow44.ai.core.messages import Message
-from flow44.ai.core.opik_failure_logger import create_span, error_info
+from flow44.ai.core.opik_failure_logger import create_span, error_info, record_span_error
 from flow44.ai.core.provider import complete_chat, stream_chat
 from flow44.ai.file_safety import (
     FileSafetyError,
@@ -53,7 +53,6 @@ class ExecuteAgent(BaseAgent):
         self._flow = self._build_flow()
 
     def _build_flow(self) -> Flow[ExecutionState]:
-        """Build the execution flow with explicit steps and routing."""
         flow = Flow[ExecutionState]("execute")
 
         flow.add_step("build_plan", self._step_build_plan, next_step="execute_tasks")
@@ -65,7 +64,6 @@ class ExecuteAgent(BaseAgent):
         return flow
 
     def _route_after_validate(self, state: ExecutionState) -> str | None:
-        """Route after validation: fix_errors, summarize, or give up."""
         if not state.all_errors and not state.rejected_files:
             return "summarize"
 
@@ -77,14 +75,11 @@ class ExecuteAgent(BaseAgent):
 
     @track(name="execute-agent-run")  # type: ignore[untyped-decorator]
     async def run(self) -> None:
-        """Run the execution flow."""
         self._setup_trace(["execute-agent"])
-        self._set_trace_input({"user_request": self._build_state.user_content})
+        self._set_trace_input({"action": "plan_approved"})
 
-        # Emit plan accepted
         await self.emit({"type": "plan_accepted", "overview": self._build_state.user_overview.model_dump()})
 
-        # Initialize execution state
         current_span = opik_context.get_current_span_data()
         exec_state = ExecutionState(
             build_state=self._build_state,
@@ -97,7 +92,6 @@ class ExecuteAgent(BaseAgent):
             llm_metadata_fn=self._llm_metadata,
         )
 
-        # Run the flow
         final_state = await self._flow.run(exec_state, start="build_plan")
 
         self._set_trace_output(
@@ -108,25 +102,20 @@ class ExecuteAgent(BaseAgent):
             }
         )
 
-        # Final cleanup
         final_state.build_state.phase = "idle"
         final_state.build_state.work_plan = None
         await self.emit({"type": "phase", "phase": "complete"})
         await self.emit({"type": "action_complete"})
 
-    # -- Flow Steps --
+    # -- Flow Steps (sequential — use @track for automatic span lifecycle) --
 
+    @track(name="build-technical-plan")  # type: ignore[untyped-decorator]
     async def _step_build_plan(self, state: ExecutionState) -> ExecutionState:
-        """Step: Build technical plan from user overview."""
         await state.emit_fn({"type": "phase", "phase": "planning"})
 
-        span = create_span(
-            trace_id=state.trace_id,
-            parent_span_id=state.root_span_id,
-            name="build-technical-plan",
-            input={"user_request": state.build_state.user_content},
-        )
-        state.observation_id = span.id
+        span_data = opik_context.get_current_span_data()
+        state.observation_id = span_data.id if span_data else None
+        opik_context.update_current_span(input={"user_request": state.build_state.user_content})
 
         try:
             state.build_state.work_plan = await self._build_technical_plan(state)
@@ -140,60 +129,54 @@ class ExecuteAgent(BaseAgent):
                 }
             )
         except Exception as exc:
-            span.end(error_info=error_info(exc))
+            record_span_error(exc)
             raise
-        else:
-            span.end(
-                output={
-                    "task_count": len(state.build_state.work_plan.tasks),
-                    "tasks": [t.title for t in state.build_state.work_plan.tasks],
-                }
-            )
 
+        opik_context.update_current_span(
+            output={
+                "task_count": len(state.build_state.work_plan.tasks),
+                "tasks": [t.title for t in state.build_state.work_plan.tasks],
+            }
+        )
         return state
 
+    @track(name="execute-plan")  # type: ignore[untyped-decorator]
     async def _step_execute_tasks(self, state: ExecutionState) -> ExecutionState:
-        """Step: Execute all tasks in parallel layers."""
         if state.build_state.work_plan is None:
             raise RuntimeError("No work plan available")
 
-        span = create_span(
-            trace_id=state.trace_id,
-            parent_span_id=state.root_span_id,
-            name="execute-plan",
+        span_data = opik_context.get_current_span_data()
+        state.observation_id = span_data.id if span_data else None
+        opik_context.update_current_span(
             input={"tasks": [t.title for t in state.build_state.work_plan.tasks]},
             metadata={
                 "total_tasks": len(state.build_state.work_plan.tasks),
                 "execution_layers": len(state.build_state.work_plan.execution_layers()),
             },
         )
-        state.observation_id = span.id
 
         try:
             await state.emit_fn({"type": "phase", "phase": "executing"})
 
-            # Pre-populate with deterministically generated data source files
             state.build_state.completed_files = dict(state.build_state.generated_data_source_files)
             state.build_state.task_files = {}
 
             for layer in state.build_state.work_plan.execution_layers():
                 await asyncio.gather(*[self._execute_task(t, state) for t in layer])
         except Exception as exc:
-            span.end(error_info=error_info(exc))
+            record_span_error(exc)
             raise
-        else:
-            failed_tasks = [t.title for t in state.build_state.work_plan.tasks if t.status == "failed"]
-            span.end(
-                output={
-                    "files_written": list(state.build_state.completed_files.keys()),
-                    "failed_tasks": failed_tasks,
-                }
-            )
 
+        failed_tasks = [t.title for t in state.build_state.work_plan.tasks if t.status == "failed"]
+        opik_context.update_current_span(
+            output={
+                "files_written": list(state.build_state.completed_files.keys()),
+                "failed_tasks": failed_tasks,
+            }
+        )
         return state
 
     async def _step_validate(self, state: ExecutionState) -> ExecutionState:
-        """Step: Validate with typecheck and build."""
         state.typecheck_errors, state.build_errors = await asyncio.gather(
             self._typecheck(state),
             self._build(state),
@@ -208,33 +191,31 @@ class ExecuteAgent(BaseAgent):
         state.all_errors = "\n\n".join(all_errors)
         return state
 
+    @track(name="fix-errors")  # type: ignore[untyped-decorator]
     async def _step_fix_errors(self, state: ExecutionState) -> ExecutionState:
-        """Step: Auto-fix validation errors."""
         await state.emit_fn({"type": "phase", "phase": "fixing"})
         state.fix_attempts += 1
 
-        span = create_span(
-            trace_id=state.trace_id,
-            parent_span_id=state.root_span_id,
-            name="fix-errors",
+        span_data = opik_context.get_current_span_data()
+        state.observation_id = span_data.id if span_data else None
+        opik_context.update_current_span(
             input={"errors": state.all_errors, "fix_attempt": state.fix_attempts},
         )
-        state.observation_id = span.id
 
         prompt = render_feedback(files=state.build_state.completed_files)
         messages: list[dict[str, Any] | Message] = [
             Message.user(format_agent_feedback(state.all_errors, state.rejected_files))
         ]
 
+        generated: list[tuple[str, str]] = []
         try:
-            generated: list[tuple[str, str]] = []
             parser = ActionParser(on_file_action=lambda p, c: generated.append((p, c)))
 
             async for chunk in stream_chat(
                 messages,
                 prompt,
                 model=state.model,
-                metadata=state.llm_metadata_fn("fix_errors", parent_span_id=span.id),
+                metadata=state.llm_metadata_fn("fix_errors", parent_span_id=state.observation_id),
             ):
                 parser.feed(chunk)
             parser.flush()
@@ -247,24 +228,21 @@ class ExecuteAgent(BaseAgent):
                     await state.emit_fn({"type": "file", "path": path, "content": content})
         except Exception as exc:
             logger.exception("[execute] Error fix pass failed")
-            span.end(error_info=error_info(exc))
-        else:
-            span.end(output={"files_fixed": [p for p, _ in generated]})
+            record_span_error(exc)
 
+        opik_context.update_current_span(output={"files_fixed": [p for p, _ in generated]})
         return state
 
+    @track(name="generate-summary")  # type: ignore[untyped-decorator]
     async def _step_summarize(self, state: ExecutionState) -> ExecutionState:
-        """Step: Generate project summary."""
         if state.rejected_files:
             await state.emit_fn({"type": "error", "message": format_rejection_feedback(state.rejected_files)})
 
-        span = create_span(
-            trace_id=state.trace_id,
-            parent_span_id=state.root_span_id,
-            name="generate-summary",
+        span_data = opik_context.get_current_span_data()
+        state.observation_id = span_data.id if span_data else None
+        opik_context.update_current_span(
             input={"files_created": list(state.build_state.completed_files.keys())},
         )
-        state.observation_id = span.id
 
         summary_data = None
         try:
@@ -293,16 +271,14 @@ class ExecuteAgent(BaseAgent):
                 await state.emit_fn({"type": "project_summary", "summary": summary_data})
         except Exception as exc:
             logger.exception("[execute] Summary generation failed")
-            span.end(error_info=error_info(exc))
-        else:
-            span.end(output=summary_data or {})
+            record_span_error(exc)
 
+        opik_context.update_current_span(output=summary_data or {})
         return state
 
     # -- Helper Methods --
 
     async def _build_technical_plan(self, state: ExecutionState) -> WorkPlan:
-        """Build technical task plan from user overview."""
         merge_data: dict[str, object] = {
             "user_request": state.build_state.user_content,
             "architecture": state.build_state.architecture.model_dump(),
@@ -364,8 +340,9 @@ class ExecuteAgent(BaseAgent):
             tasks=tasks,
         )
 
+    # Stays manual — runs in parallel via asyncio.gather, contextvar parent tracking
+    # doesn't work with multiple concurrent invocations of the same method.
     async def _execute_task(self, task: Task, state: ExecutionState) -> None:
-        """Execute a single task with an Opik span."""
         if state.build_state.work_plan is None:
             raise RuntimeError("No work plan available")
 
@@ -440,11 +417,9 @@ class ExecuteAgent(BaseAgent):
             span.end(error_info=error_info(exc))
 
     async def _typecheck(self, state: ExecutionState) -> str:
-        """Run TypeScript typecheck."""
         result = await state.sandbox_ref.run_build_command("npx tsc --noEmit")
         return str(result.errors)
 
     async def _build(self, state: ExecutionState) -> str:
-        """Run build command."""
         result = await state.sandbox_ref.run_build_command("pnpm build")
         return str(result.errors)

--- a/backend/src/flow44/ai/agents/execute/agent.py
+++ b/backend/src/flow44/ai/agents/execute/agent.py
@@ -79,6 +79,12 @@ class ExecuteAgent(BaseAgent):
     async def run(self) -> None:
         """Run the execution flow."""
         self._setup_trace(["execute-agent"])
+        self._set_trace_input(
+            {
+                "user_request": self._build_state.user_content,
+                "user_overview": self._build_state.user_overview.model_dump(),
+            }
+        )
 
         # Emit plan accepted
         await self.emit({"type": "plan_accepted", "overview": self._build_state.user_overview.model_dump()})

--- a/backend/src/flow44/ai/agents/execute/agent.py
+++ b/backend/src/flow44/ai/agents/execute/agent.py
@@ -78,7 +78,7 @@ class ExecuteAgent(BaseAgent):
         self._setup_trace(["execute-agent"])
         self._set_trace_input({"action": "plan_approved"})
 
-        await self.emit({"type": "plan_accepted", "overview": self._build_state.user_overview.model_dump()})
+        await self.emit({"type": "plan_accepted", "overview": self._build_state.user_plan_overview.model_dump()})
 
         current_span = opik_context.get_current_span_data()
         exec_state = ExecutionState(
@@ -283,7 +283,7 @@ class ExecuteAgent(BaseAgent):
             "user_request": state.build_state.user_content,
             "architecture": state.build_state.architecture.model_dump(),
             "ux_design": state.build_state.ux_design.model_dump(),
-            "user_preferences": [d.model_dump() for d in state.build_state.user_overview.decisions],
+            "user_preferences": [d.model_dump() for d in state.build_state.user_plan_overview.decisions],
         }
         if state.build_state.data_source_contexts:
             merge_data["data_source_integrations"] = [

--- a/backend/src/flow44/ai/agents/execute/agent.py
+++ b/backend/src/flow44/ai/agents/execute/agent.py
@@ -4,7 +4,7 @@ import logging
 import uuid
 from typing import Any
 
-from opik import Opik, opik_context, track
+from opik import get_global_client, opik_context, track
 
 from flow44.ai.agents._base import BaseAgent
 from flow44.ai.agents.execute.execution_state import ExecutionState
@@ -92,7 +92,7 @@ class ExecuteAgent(BaseAgent):
             model=self.model,
             trace_id=self._trace_id,
             root_span_id=current_span.id if current_span else None,
-            opik_client=Opik(),
+            opik_client=get_global_client(),
             llm_metadata_fn=self._llm_metadata,
         )
 
@@ -119,7 +119,8 @@ class ExecuteAgent(BaseAgent):
         """Step: Build technical plan from user overview."""
         await state.emit_fn({"type": "phase", "phase": "planning"})
 
-        span = state.opik_client.span(
+        span = self._safe_span(
+            state.opik_client,
             trace_id=state.trace_id,
             parent_span_id=state.root_span_id,
             name="build-technical-plan",
@@ -156,7 +157,8 @@ class ExecuteAgent(BaseAgent):
         if state.build_state.work_plan is None:
             raise RuntimeError("No work plan available")
 
-        span = state.opik_client.span(
+        span = self._safe_span(
+            state.opik_client,
             trace_id=state.trace_id,
             parent_span_id=state.root_span_id,
             name="execute-plan",
@@ -212,7 +214,8 @@ class ExecuteAgent(BaseAgent):
         await state.emit_fn({"type": "phase", "phase": "fixing"})
         state.fix_attempts += 1
 
-        span = state.opik_client.span(
+        span = self._safe_span(
+            state.opik_client,
             trace_id=state.trace_id,
             parent_span_id=state.root_span_id,
             name="fix-errors",
@@ -257,7 +260,8 @@ class ExecuteAgent(BaseAgent):
         if state.rejected_files:
             await state.emit_fn({"type": "error", "message": format_rejection_feedback(state.rejected_files)})
 
-        span = state.opik_client.span(
+        span = self._safe_span(
+            state.opik_client,
             trace_id=state.trace_id,
             parent_span_id=state.root_span_id,
             name="generate-summary",
@@ -368,7 +372,8 @@ class ExecuteAgent(BaseAgent):
         if state.build_state.work_plan is None:
             raise RuntimeError("No work plan available")
 
-        span = state.opik_client.span(
+        span = self._safe_span(
+            state.opik_client,
             trace_id=state.trace_id,
             parent_span_id=state.observation_id,
             name=f"execute-task-{task.id}",

--- a/backend/src/flow44/ai/agents/execute/agent.py
+++ b/backend/src/flow44/ai/agents/execute/agent.py
@@ -4,8 +4,7 @@ import logging
 import uuid
 from typing import Any
 
-from langfuse import Langfuse
-from langfuse.decorators import observe
+from opik import Opik, opik_context, track
 
 from flow44.ai.agents._base import BaseAgent
 from flow44.ai.agents.execute.execution_state import ExecutionState
@@ -75,7 +74,7 @@ class ExecuteAgent(BaseAgent):
 
         return "fix_errors"
 
-    @observe(name="execute-agent-run")  # type: ignore[untyped-decorator]
+    @track(name="execute-agent-run")  # type: ignore[untyped-decorator]
     async def run(self) -> None:
         """Run the execution flow."""
         self._setup_trace(["execute-agent"])
@@ -84,6 +83,7 @@ class ExecuteAgent(BaseAgent):
         await self.emit({"type": "plan_accepted", "overview": self._build_state.user_overview.model_dump()})
 
         # Initialize execution state
+        current_span = opik_context.get_current_span_data()
         exec_state = ExecutionState(
             build_state=self._build_state,
             project_id=self.project_id,
@@ -91,12 +91,21 @@ class ExecuteAgent(BaseAgent):
             emit_fn=self.emit,
             model=self.model,
             trace_id=self._trace_id,
-            langfuse_client=Langfuse(),
+            root_span_id=current_span.id if current_span else None,
+            opik_client=Opik(),
             llm_metadata_fn=self._llm_metadata,
         )
 
         # Run the flow
         final_state = await self._flow.run(exec_state, start="build_plan")
+
+        self._set_trace_output(
+            {
+                "files_written": list(final_state.build_state.completed_files.keys()),
+                "fix_attempts": final_state.fix_attempts,
+                "rejected_files": [str(r) for r in final_state.rejected_files],
+            }
+        )
 
         # Final cleanup
         final_state.build_state.phase = "idle"
@@ -110,7 +119,12 @@ class ExecuteAgent(BaseAgent):
         """Step: Build technical plan from user overview."""
         await state.emit_fn({"type": "phase", "phase": "planning"})
 
-        span = state.langfuse_client.span(trace_id=state.trace_id, name="build-technical-plan")
+        span = state.opik_client.span(
+            trace_id=state.trace_id,
+            parent_span_id=state.root_span_id,
+            name="build-technical-plan",
+            input={"user_request": state.build_state.user_content},
+        )
         state.observation_id = span.id
 
         try:
@@ -124,8 +138,16 @@ class ExecuteAgent(BaseAgent):
                     ],
                 }
             )
-        finally:
-            span.end()
+        except Exception as exc:
+            span.end(error_info=self._error_info(exc))
+            raise
+        else:
+            span.end(
+                output={
+                    "task_count": len(state.build_state.work_plan.tasks),
+                    "tasks": [t.title for t in state.build_state.work_plan.tasks],
+                }
+            )
 
         return state
 
@@ -134,9 +156,11 @@ class ExecuteAgent(BaseAgent):
         if state.build_state.work_plan is None:
             raise RuntimeError("No work plan available")
 
-        span = state.langfuse_client.span(
+        span = state.opik_client.span(
             trace_id=state.trace_id,
+            parent_span_id=state.root_span_id,
             name="execute-plan",
+            input={"tasks": [t.title for t in state.build_state.work_plan.tasks]},
             metadata={
                 "total_tasks": len(state.build_state.work_plan.tasks),
                 "execution_layers": len(state.build_state.work_plan.execution_layers()),
@@ -153,8 +177,17 @@ class ExecuteAgent(BaseAgent):
 
             for layer in state.build_state.work_plan.execution_layers():
                 await asyncio.gather(*[self._execute_task(t, state) for t in layer])
-        finally:
-            span.end()
+        except Exception as exc:
+            span.end(error_info=self._error_info(exc))
+            raise
+        else:
+            failed_tasks = [t.title for t in state.build_state.work_plan.tasks if t.status == "failed"]
+            span.end(
+                output={
+                    "files_written": list(state.build_state.completed_files.keys()),
+                    "failed_tasks": failed_tasks,
+                }
+            )
 
         return state
 
@@ -179,6 +212,14 @@ class ExecuteAgent(BaseAgent):
         await state.emit_fn({"type": "phase", "phase": "fixing"})
         state.fix_attempts += 1
 
+        span = state.opik_client.span(
+            trace_id=state.trace_id,
+            parent_span_id=state.root_span_id,
+            name="fix-errors",
+            input={"errors": state.all_errors, "fix_attempt": state.fix_attempts},
+        )
+        state.observation_id = span.id
+
         prompt = render_feedback(files=state.build_state.completed_files)
         messages: list[dict[str, Any] | Message] = [
             Message.user(format_agent_feedback(state.all_errors, state.rejected_files))
@@ -192,7 +233,7 @@ class ExecuteAgent(BaseAgent):
                 messages,
                 prompt,
                 model=state.model,
-                metadata=state.llm_metadata_fn("fix_errors"),
+                metadata=state.llm_metadata_fn("fix_errors", parent_span_id=span.id),
             ):
                 parser.feed(chunk)
             parser.flush()
@@ -203,8 +244,11 @@ class ExecuteAgent(BaseAgent):
                     await state.sandbox_ref.write_file(path, content)
                     state.build_state.completed_files[path] = content
                     await state.emit_fn({"type": "file", "path": path, "content": content})
-        except Exception:
+        except Exception as exc:
             logger.exception("[execute] Error fix pass failed")
+            span.end(error_info=self._error_info(exc))
+        else:
+            span.end(output={"files_fixed": [p for p, _ in generated]})
 
         return state
 
@@ -213,9 +257,15 @@ class ExecuteAgent(BaseAgent):
         if state.rejected_files:
             await state.emit_fn({"type": "error", "message": format_rejection_feedback(state.rejected_files)})
 
-        span = state.langfuse_client.span(trace_id=state.trace_id, name="generate-summary")
+        span = state.opik_client.span(
+            trace_id=state.trace_id,
+            parent_span_id=state.root_span_id,
+            name="generate-summary",
+            input={"files_created": list(state.build_state.completed_files.keys())},
+        )
         state.observation_id = span.id
 
+        summary_data = None
         try:
             summary_input = json.dumps(
                 {
@@ -229,7 +279,7 @@ class ExecuteAgent(BaseAgent):
                 [Message.user(summary_input)],
                 SUMMARY_PROMPT,
                 model=state.model,
-                metadata=state.llm_metadata_fn("generate_summary"),
+                metadata=state.llm_metadata_fn("generate_summary", parent_span_id=state.observation_id),
             )
             summary_data = parse_json_response(raw)
             if summary_data:
@@ -240,10 +290,11 @@ class ExecuteAgent(BaseAgent):
                     }
                 await update_project_summary(state.project_id, json.dumps(summary_data, ensure_ascii=False))
                 await state.emit_fn({"type": "project_summary", "summary": summary_data})
-        except Exception:
+        except Exception as exc:
             logger.exception("[execute] Summary generation failed")
-        finally:
-            span.end()
+            span.end(error_info=self._error_info(exc))
+        else:
+            span.end(output=summary_data or {})
 
         return state
 
@@ -277,7 +328,7 @@ class ExecuteAgent(BaseAgent):
             [Message.user(json.dumps(merge_data, indent=2))],
             render_merge(has_data_sources=bool(state.build_state.data_source_contexts)),
             model=state.model,
-            metadata=state.llm_metadata_fn("build_technical_plan"),
+            metadata=state.llm_metadata_fn("build_technical_plan", parent_span_id=state.observation_id),
         )
         plan_data = parse_json_response(raw)
 
@@ -313,14 +364,15 @@ class ExecuteAgent(BaseAgent):
         )
 
     async def _execute_task(self, task: Task, state: ExecutionState) -> None:
-        """Execute a single task with Langfuse span."""
+        """Execute a single task with an Opik span."""
         if state.build_state.work_plan is None:
             raise RuntimeError("No work plan available")
 
-        span = state.langfuse_client.span(
+        span = state.opik_client.span(
             trace_id=state.trace_id,
-            parent_observation_id=state.observation_id,
+            parent_span_id=state.observation_id,
             name=f"execute-task-{task.id}",
+            input={"task_title": task.title, "task_description": task.description, "expected_files": task.files},
             metadata={"task_id": task.id, "task_title": task.title, "expected_files": len(task.files)},
         )
 
@@ -350,7 +402,7 @@ class ExecuteAgent(BaseAgent):
                 [Message.user("Generate the code.")],
                 prompt,
                 model=state.model,
-                metadata=state.llm_metadata_fn(f"execute_task_{task.id}"),
+                metadata=state.llm_metadata_fn(f"execute_task_{task.id}", parent_span_id=span.id),
             ):
                 parser.feed(chunk)
             parser.flush()
@@ -378,13 +430,13 @@ class ExecuteAgent(BaseAgent):
             state.build_state.task_files[task.id] = paths
             task.status = "completed"
             await state.emit_fn({"type": "task_update", "taskId": task.id, "status": "completed"})
+            span.end(output={"files_written": paths, "rejected_files": [str(r) for r in rejections]})
         except Exception as exc:
             logger.exception("[execute] Task %s failed", task.id)
             task.status = "failed"
             task.error = str(exc)
             await state.emit_fn({"type": "task_update", "taskId": task.id, "status": "failed"})
-        finally:
-            span.end()
+            span.end(error_info=self._error_info(exc))
 
     async def _typecheck(self, state: ExecutionState) -> str:
         """Run TypeScript typecheck."""

--- a/backend/src/flow44/ai/agents/execute/agent.py
+++ b/backend/src/flow44/ai/agents/execute/agent.py
@@ -4,7 +4,7 @@ import logging
 import uuid
 from typing import Any
 
-from opik import get_global_client, opik_context, track
+from opik import opik_context, track
 
 from flow44.ai.agents._base import BaseAgent
 from flow44.ai.agents.execute.execution_state import ExecutionState
@@ -17,6 +17,7 @@ from flow44.ai.agents.execute.prompts import (
 )
 from flow44.ai.core.flow import Flow
 from flow44.ai.core.messages import Message
+from flow44.ai.core.opik_failure_logger import create_span, error_info
 from flow44.ai.core.provider import complete_chat, stream_chat
 from flow44.ai.file_safety import (
     FileSafetyError,
@@ -92,7 +93,6 @@ class ExecuteAgent(BaseAgent):
             model=self.model,
             trace_id=self._trace_id,
             root_span_id=current_span.id if current_span else None,
-            opik_client=get_global_client(),
             llm_metadata_fn=self._llm_metadata,
         )
 
@@ -119,8 +119,7 @@ class ExecuteAgent(BaseAgent):
         """Step: Build technical plan from user overview."""
         await state.emit_fn({"type": "phase", "phase": "planning"})
 
-        span = self._safe_span(
-            state.opik_client,
+        span = create_span(
             trace_id=state.trace_id,
             parent_span_id=state.root_span_id,
             name="build-technical-plan",
@@ -140,7 +139,7 @@ class ExecuteAgent(BaseAgent):
                 }
             )
         except Exception as exc:
-            span.end(error_info=self._error_info(exc))
+            span.end(error_info=error_info(exc))
             raise
         else:
             span.end(
@@ -157,8 +156,7 @@ class ExecuteAgent(BaseAgent):
         if state.build_state.work_plan is None:
             raise RuntimeError("No work plan available")
 
-        span = self._safe_span(
-            state.opik_client,
+        span = create_span(
             trace_id=state.trace_id,
             parent_span_id=state.root_span_id,
             name="execute-plan",
@@ -180,7 +178,7 @@ class ExecuteAgent(BaseAgent):
             for layer in state.build_state.work_plan.execution_layers():
                 await asyncio.gather(*[self._execute_task(t, state) for t in layer])
         except Exception as exc:
-            span.end(error_info=self._error_info(exc))
+            span.end(error_info=error_info(exc))
             raise
         else:
             failed_tasks = [t.title for t in state.build_state.work_plan.tasks if t.status == "failed"]
@@ -214,8 +212,7 @@ class ExecuteAgent(BaseAgent):
         await state.emit_fn({"type": "phase", "phase": "fixing"})
         state.fix_attempts += 1
 
-        span = self._safe_span(
-            state.opik_client,
+        span = create_span(
             trace_id=state.trace_id,
             parent_span_id=state.root_span_id,
             name="fix-errors",
@@ -249,7 +246,7 @@ class ExecuteAgent(BaseAgent):
                     await state.emit_fn({"type": "file", "path": path, "content": content})
         except Exception as exc:
             logger.exception("[execute] Error fix pass failed")
-            span.end(error_info=self._error_info(exc))
+            span.end(error_info=error_info(exc))
         else:
             span.end(output={"files_fixed": [p for p, _ in generated]})
 
@@ -260,8 +257,7 @@ class ExecuteAgent(BaseAgent):
         if state.rejected_files:
             await state.emit_fn({"type": "error", "message": format_rejection_feedback(state.rejected_files)})
 
-        span = self._safe_span(
-            state.opik_client,
+        span = create_span(
             trace_id=state.trace_id,
             parent_span_id=state.root_span_id,
             name="generate-summary",
@@ -296,7 +292,7 @@ class ExecuteAgent(BaseAgent):
                 await state.emit_fn({"type": "project_summary", "summary": summary_data})
         except Exception as exc:
             logger.exception("[execute] Summary generation failed")
-            span.end(error_info=self._error_info(exc))
+            span.end(error_info=error_info(exc))
         else:
             span.end(output=summary_data or {})
 
@@ -372,8 +368,7 @@ class ExecuteAgent(BaseAgent):
         if state.build_state.work_plan is None:
             raise RuntimeError("No work plan available")
 
-        span = self._safe_span(
-            state.opik_client,
+        span = create_span(
             trace_id=state.trace_id,
             parent_span_id=state.observation_id,
             name=f"execute-task-{task.id}",
@@ -441,7 +436,7 @@ class ExecuteAgent(BaseAgent):
             task.status = "failed"
             task.error = str(exc)
             await state.emit_fn({"type": "task_update", "taskId": task.id, "status": "failed"})
-            span.end(error_info=self._error_info(exc))
+            span.end(error_info=error_info(exc))
 
     async def _typecheck(self, state: ExecutionState) -> str:
         """Run TypeScript typecheck."""

--- a/backend/src/flow44/ai/agents/execute/agent.py
+++ b/backend/src/flow44/ai/agents/execute/agent.py
@@ -79,12 +79,7 @@ class ExecuteAgent(BaseAgent):
     async def run(self) -> None:
         """Run the execution flow."""
         self._setup_trace(["execute-agent"])
-        self._set_trace_input(
-            {
-                "user_request": self._build_state.user_content,
-                "user_overview": self._build_state.user_overview.model_dump(),
-            }
-        )
+        self._set_trace_input({"user_request": self._build_state.user_content})
 
         # Emit plan accepted
         await self.emit({"type": "plan_accepted", "overview": self._build_state.user_overview.model_dump()})

--- a/backend/src/flow44/ai/agents/execute/execution_state.py
+++ b/backend/src/flow44/ai/agents/execute/execution_state.py
@@ -20,7 +20,6 @@ class ExecutionState(BaseModel):
     trace_id: str | None = None
     root_span_id: str | None = None  # The `run()` @track span — parent for top-level step spans
     observation_id: str | None = None
-    opik_client: Any = None  # Hold reference
     llm_metadata_fn: Any = None  # Function to generate metadata
 
     # Validation results

--- a/backend/src/flow44/ai/agents/execute/execution_state.py
+++ b/backend/src/flow44/ai/agents/execute/execution_state.py
@@ -18,8 +18,9 @@ class ExecutionState(BaseModel):
     emit_fn: Any = None  # Can't serialize function
     model: str | None = None
     trace_id: str | None = None
+    root_span_id: str | None = None  # The `run()` @track span — parent for top-level step spans
     observation_id: str | None = None
-    langfuse_client: Any = None  # Hold reference
+    opik_client: Any = None  # Hold reference
     llm_metadata_fn: Any = None  # Function to generate metadata
 
     # Validation results

--- a/backend/src/flow44/ai/agents/fix_error/agent.py
+++ b/backend/src/flow44/ai/agents/fix_error/agent.py
@@ -9,6 +9,7 @@ from flow44.ai.agents.fix_error.fix_error_state import FixErrorState
 from flow44.ai.agents.fix_error.prompts import render_feedback, render_fix_error_direct
 from flow44.ai.core.flow import Flow
 from flow44.ai.core.messages import Message
+from flow44.ai.core.opik_failure_logger import record_span_error
 from flow44.ai.core.provider import stream_chat
 from flow44.ai.file_safety import format_rejection_feedback, screen_generated_files
 from flow44.ai.helpers import format_agent_feedback
@@ -254,7 +255,7 @@ class FixErrorAgent(ChatAgent):
             )
         except Exception as exc:
             logger.exception("[fix-error] Retry fix failed")
-            self._record_span_error(exc)
+            record_span_error(exc)
             await state.emit_fn({"type": "fix_step", "step": "retry", "status": "failed", "message": "Auto-fix failed"})
 
         return state

--- a/backend/src/flow44/ai/agents/fix_error/agent.py
+++ b/backend/src/flow44/ai/agents/fix_error/agent.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import PurePosixPath
 from typing import Any
 
-from langfuse.decorators import observe
+from opik import track
 
 from flow44.ai.agents._chat_agent import ChatAgent
 from flow44.ai.agents.fix_error.fix_error_state import FixErrorState
@@ -58,7 +58,7 @@ class FixErrorAgent(ChatAgent):
 
         return "retry"
 
-    @observe(name="fix-error-agent-run")  # type: ignore[untyped-decorator]
+    @track(name="fix-error-agent-run")  # type: ignore[untyped-decorator]
     async def run(
         self,
         error_message: str,
@@ -252,8 +252,9 @@ class FixErrorAgent(ChatAgent):
             await state.emit_fn(
                 {"type": "fix_step", "step": "retry", "status": "completed", "message": "Auto-fix applied"}
             )
-        except Exception:
+        except Exception as exc:
             logger.exception("[fix-error] Retry fix failed")
+            self._record_span_error(exc)
             await state.emit_fn({"type": "fix_step", "step": "retry", "status": "failed", "message": "Auto-fix failed"})
 
         return state
@@ -274,6 +275,16 @@ class FixErrorAgent(ChatAgent):
         await self._save_response(state.explanation, steps)
 
         await self._emit_file_diffs_summary(state.diffs)
+
+        self._set_trace_output(
+            {
+                "explanation": state.explanation,
+                "files_fixed": files,
+                "retry_count": state.retry_count,
+                "validated": not state.validation_errors,
+            }
+        )
+
         await state.emit_fn({"type": "action_complete"})
         await state.emit_fn({"type": "phase", "phase": "idle"})
         return state

--- a/backend/src/flow44/ai/agents/followup/agent.py
+++ b/backend/src/flow44/ai/agents/followup/agent.py
@@ -3,7 +3,7 @@ import json
 import uuid
 from typing import Any
 
-from langfuse.decorators import observe
+from opik import track
 from pydantic import BaseModel
 
 from flow44.ai.agents._chat_agent import ChatAgent
@@ -145,7 +145,7 @@ class FollowUpAgent(ChatAgent):
 
         return ToolExecutor([grep, glob, read_file, write_file, edit_file])
 
-    @observe(name="followup-agent-run")  # type: ignore[untyped-decorator]
+    @track(name="followup-agent-run")  # type: ignore[untyped-decorator]
     async def run(self, content: str, data_source_ids: list[str] | None = None) -> None:
         self._setup_trace(["follow-up-agent"])
 
@@ -192,7 +192,7 @@ class FollowUpAgent(ChatAgent):
             system_prompt=system_prompt,
             tools=self._executor,
             model=self.model,
-            metadata_fn=lambda step: self._llm_metadata(f"followup-{step}"),
+            metadata_fn=lambda step, **kwargs: self._llm_metadata(f"followup-{step}", **kwargs),
             emit_fn=self._emit_react_step,
         )
 
@@ -202,6 +202,8 @@ class FollowUpAgent(ChatAgent):
         await self._save_response(answer or "", self._steps)
 
         await self._emit_file_diffs_summary(self._diffs)
+
+        self._set_trace_output({"answer": answer or "", "steps": len(self._steps)})
 
         # TODO: do we need both events?
         await self.emit({"type": "phase", "phase": "complete"})

--- a/backend/src/flow44/ai/agents/plan/agent.py
+++ b/backend/src/flow44/ai/agents/plan/agent.py
@@ -76,7 +76,7 @@ class PlanAgent(BaseAgent):
         start_step = "fetch_data_sources" if self._state.data_source_ids else "design"
         await self._flow.run(plan_state, start=start_step)
 
-        self._set_trace_output({"user_overview": self._state.user_overview.model_dump()})
+        self._set_trace_output({"user_plan_overview": self._state.user_plan_overview.model_dump()})
 
     # -- Flow Steps --
 
@@ -162,7 +162,7 @@ class PlanAgent(BaseAgent):
         """Step: Build user overview from designs."""
         await state.emit_fn({"type": "phase", "phase": "planning"})
 
-        state.build_state.user_overview = await self._build_user_overview()
+        state.build_state.user_plan_overview = await self._build_user_overview()
 
         return state
 
@@ -171,7 +171,7 @@ class PlanAgent(BaseAgent):
         state.build_state.phase = "awaiting_approval"
         await save_pending_plan(state.project_id, state.build_state.model_dump_json())
         await state.emit_fn({"type": "phase", "phase": "awaiting_approval"})
-        await state.emit_fn({"type": "plan_overview", "overview": state.build_state.user_overview.model_dump()})
+        await state.emit_fn({"type": "plan_overview", "overview": state.build_state.user_plan_overview.model_dump()})
 
         return state
 
@@ -190,7 +190,7 @@ class PlanAgent(BaseAgent):
                 "user_request": self._state.user_content,
                 "architecture": self._state.architecture.model_dump(),
                 "ux_design": self._state.ux_design.model_dump(),
-                "previous_overview": self._state.user_overview.model_dump(),
+                "previous_overview": self._state.user_plan_overview.model_dump(),
                 "user_feedback": feedback,
             },
             indent=2,
@@ -201,14 +201,14 @@ class PlanAgent(BaseAgent):
             model=self.model,
             metadata=self._llm_metadata("rebuild_user_plan"),
         )
-        self._state.user_overview = UserPlanOverview.model_validate(parse_json_response(raw))
+        self._state.user_plan_overview = UserPlanOverview.model_validate(parse_json_response(raw))
 
         self._state.phase = "awaiting_approval"
         await save_pending_plan(self.project_id, self._state.model_dump_json())
         await self.emit({"type": "phase", "phase": "awaiting_approval"})
-        await self.emit({"type": "plan_overview", "overview": self._state.user_overview.model_dump()})
+        await self.emit({"type": "plan_overview", "overview": self._state.user_plan_overview.model_dump()})
 
-        self._set_trace_output({"user_overview": self._state.user_overview.model_dump()})
+        self._set_trace_output({"user_plan_overview": self._state.user_plan_overview.model_dump()})
 
     # -- Design --
 

--- a/backend/src/flow44/ai/agents/plan/agent.py
+++ b/backend/src/flow44/ai/agents/plan/agent.py
@@ -15,6 +15,7 @@ from flow44.ai.agents.plan.prompts import (
 )
 from flow44.ai.core.flow import Flow
 from flow44.ai.core.messages import Message
+from flow44.ai.core.opik_failure_logger import record_span_error
 from flow44.ai.core.provider import complete_chat
 from flow44.ai.helpers import parse_json_response
 from flow44.ai.state import BuildState
@@ -225,7 +226,7 @@ class PlanAgent(BaseAgent):
             return ArchitectureDesign.model_validate(parse_json_response(raw))
         except Exception as exc:
             logger.exception("[plan] Architecture design failed")
-            self._record_span_error(exc)
+            record_span_error(exc)
             await self.emit({"type": "design_progress", "stream": "architecture", "content": "failed"})
             return ArchitectureDesign()
 
@@ -242,7 +243,7 @@ class PlanAgent(BaseAgent):
             return UXDesign.model_validate(parse_json_response(raw))
         except Exception as exc:
             logger.exception("[plan] UX design failed")
-            self._record_span_error(exc)
+            record_span_error(exc)
             await self.emit({"type": "design_progress", "stream": "ux", "content": "failed"})
             return UXDesign()
 

--- a/backend/src/flow44/ai/agents/plan/agent.py
+++ b/backend/src/flow44/ai/agents/plan/agent.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 
-from langfuse.decorators import observe
+from opik import track
 
 from flow44.ai.agents._base import BaseAgent
 from flow44.ai.agents.analyze_data_source import fetch_and_analyze_data_source, generate_data_source_files
@@ -53,7 +53,7 @@ class PlanAgent(BaseAgent):
 
         return flow
 
-    @observe(name="plan-agent-run")  # type: ignore[untyped-decorator]
+    @track(name="plan-agent-run")  # type: ignore[untyped-decorator]
     async def run(self, content: str, data_source_ids: list[str] | None = None) -> None:
         self._state.user_content = content
         self._state.data_source_ids = data_source_ids or []
@@ -74,6 +74,8 @@ class PlanAgent(BaseAgent):
         # Run the flow
         start_step = "fetch_data_sources" if self._state.data_source_ids else "design"
         await self._flow.run(plan_state, start=start_step)
+
+        self._set_trace_output({"user_overview": self._state.user_overview.model_dump()})
 
     # -- Flow Steps --
 
@@ -174,7 +176,7 @@ class PlanAgent(BaseAgent):
 
     # -- Rebuild --
 
-    @observe(name="plan-agent-rebuild")  # type: ignore[untyped-decorator]
+    @track(name="plan-agent-rebuild")  # type: ignore[untyped-decorator]
     async def rebuild_with_feedback(self, state: BuildState, feedback: str) -> None:
         """Rebuild the user overview incorporating feedback, then persist."""
         self._state = state
@@ -205,9 +207,11 @@ class PlanAgent(BaseAgent):
         await self.emit({"type": "phase", "phase": "awaiting_approval"})
         await self.emit({"type": "plan_overview", "overview": self._state.user_overview.model_dump()})
 
+        self._set_trace_output({"user_overview": self._state.user_overview.model_dump()})
+
     # -- Design --
 
-    @observe(name="design-architecture")  # type: ignore[untyped-decorator]
+    @track(name="design-architecture")  # type: ignore[untyped-decorator]
     async def _design_architecture(self) -> ArchitectureDesign:
         prompt = render_architecture(data_source_contexts=self._state.data_source_contexts or None)
         try:
@@ -219,12 +223,13 @@ class PlanAgent(BaseAgent):
             )
             await self.emit({"type": "design_progress", "stream": "architecture", "content": "complete"})
             return ArchitectureDesign.model_validate(parse_json_response(raw))
-        except Exception:
+        except Exception as exc:
             logger.exception("[plan] Architecture design failed")
+            self._record_span_error(exc)
             await self.emit({"type": "design_progress", "stream": "architecture", "content": "failed"})
             return ArchitectureDesign()
 
-    @observe(name="design-ux")  # type: ignore[untyped-decorator]
+    @track(name="design-ux")  # type: ignore[untyped-decorator]
     async def _design_ux(self) -> UXDesign:
         try:
             raw = await complete_chat(
@@ -235,12 +240,13 @@ class PlanAgent(BaseAgent):
             )
             await self.emit({"type": "design_progress", "stream": "ux", "content": "complete"})
             return UXDesign.model_validate(parse_json_response(raw))
-        except Exception:
+        except Exception as exc:
             logger.exception("[plan] UX design failed")
+            self._record_span_error(exc)
             await self.emit({"type": "design_progress", "stream": "ux", "content": "failed"})
             return UXDesign()
 
-    @observe(name="build-user-overview")  # type: ignore[untyped-decorator]
+    @track(name="build-user-overview")  # type: ignore[untyped-decorator]
     async def _build_user_overview(self) -> UserPlanOverview:
         plan_input = json.dumps(
             {

--- a/backend/src/flow44/ai/agents/plan/agent.py
+++ b/backend/src/flow44/ai/agents/plan/agent.py
@@ -162,7 +162,7 @@ class PlanAgent(BaseAgent):
         """Step: Build user overview from designs."""
         await state.emit_fn({"type": "phase", "phase": "planning"})
 
-        state.build_state.user_plan_overview = await self._build_user_overview()
+        state.build_state.user_plan_overview = await self._build_user_plan_overview()
 
         return state
 
@@ -247,8 +247,8 @@ class PlanAgent(BaseAgent):
             await self.emit({"type": "design_progress", "stream": "ux", "content": "failed"})
             return UXDesign()
 
-    @track(name="build-user-overview")  # type: ignore[untyped-decorator]
-    async def _build_user_overview(self) -> UserPlanOverview:
+    @track(name="build-user-plan-overview")  # type: ignore[untyped-decorator]
+    async def _build_user_plan_overview(self) -> UserPlanOverview:
         plan_input = json.dumps(
             {
                 "user_request": self._state.user_content,

--- a/backend/src/flow44/ai/agents/plan/agent.py
+++ b/backend/src/flow44/ai/agents/plan/agent.py
@@ -177,7 +177,7 @@ class PlanAgent(BaseAgent):
 
     # -- Rebuild --
 
-    @track(name="plan-agent-rebuild")  # type: ignore[untyped-decorator]
+    @track(name="plan-agent-rebuild", ignore_arguments=["state"])  # type: ignore[untyped-decorator]
     async def rebuild_with_feedback(self, state: BuildState, feedback: str) -> None:
         """Rebuild the user overview incorporating feedback, then persist."""
         self._state = state

--- a/backend/src/flow44/ai/core/opik_failure_logger.py
+++ b/backend/src/flow44/ai/core/opik_failure_logger.py
@@ -1,0 +1,67 @@
+import logging
+from datetime import datetime
+from typing import Any
+
+from litellm.integrations.opik.opik import OpikLogger
+from litellm.integrations.opik.opik_payload_builder import extractors
+
+logger = logging.getLogger(__name__)
+
+
+class FailureAwareOpikLogger(OpikLogger):
+    async def async_log_failure_event(
+        self,
+        kwargs: dict[str, Any],
+        response_obj: Any,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> None:
+        self._log_failure(kwargs, start_time, end_time)
+
+    def log_failure_event(
+        self,
+        kwargs: dict[str, Any],
+        response_obj: Any,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> None:
+        self._log_failure(kwargs, start_time, end_time)
+
+    def _log_failure(self, kwargs: dict[str, Any], start_time: datetime, end_time: datetime) -> None:
+        if self._opik_client is None:
+            # No native Opik client available (e.g. `opik` package not installed) — the
+            # batch-queue path this subclass would otherwise fall back to only knows how to
+            # build success payloads, so there's nothing safe to do here.
+            return  # type: ignore[unreachable]
+
+        try:
+            exception = kwargs.get("exception")
+            error_info = {
+                "exception_type": type(exception).__name__ if exception else "Unknown",
+                "traceback": str(kwargs.get("traceback_exception") or ""),
+                "message": str(exception) if exception else "LLM call failed",
+            }
+
+            litellm_params = kwargs.get("litellm_params", {}) or {}
+            litellm_metadata = litellm_params.get("metadata", {}) or {}
+            standard_logging_object = kwargs.get("standard_logging_object", {}) or {}
+            standard_logging_metadata = standard_logging_object.get("metadata", {}) or {}
+
+            opik_metadata = extractors.extract_opik_metadata(litellm_metadata, standard_logging_metadata)
+            current_span_data = opik_metadata.get("current_span_data")
+            trace_id, parent_span_id = extractors.extract_span_identifiers(current_span_data)
+
+            self._opik_client.span(
+                trace_id=trace_id,
+                parent_span_id=parent_span_id,
+                name=f"{kwargs.get('model', 'unknown-model')}_failure",
+                type="llm",
+                model=kwargs.get("model"),
+                start_time=start_time,
+                end_time=end_time,
+                input={"messages": kwargs.get("messages")},
+                error_info=error_info,  # type: ignore[arg-type]
+                project_name=self.opik_project_name,
+            )
+        except Exception:
+            logger.exception("FailureAwareOpikLogger failed to log failure event")

--- a/backend/src/flow44/ai/core/opik_failure_logger.py
+++ b/backend/src/flow44/ai/core/opik_failure_logger.py
@@ -1,14 +1,21 @@
 import logging
+import traceback as traceback_module
 from datetime import datetime
 from typing import Any
 
 from litellm.integrations.opik.opik import OpikLogger
 from litellm.integrations.opik.opik_payload_builder import extractors
+from opik import Span, get_global_client, opik_context
+from opik.types import ErrorInfoDict
 
 logger = logging.getLogger(__name__)
 
 
 class FailureAwareOpikLogger(OpikLogger):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._opik_client = get_global_client()
+
     async def async_log_failure_event(
         self,
         kwargs: dict[str, Any],
@@ -28,12 +35,6 @@ class FailureAwareOpikLogger(OpikLogger):
         self._log_failure(kwargs, start_time, end_time)
 
     def _log_failure(self, kwargs: dict[str, Any], start_time: datetime, end_time: datetime) -> None:
-        if self._opik_client is None:
-            # No native Opik client available (e.g. `opik` package not installed) — the
-            # batch-queue path this subclass would otherwise fall back to only knows how to
-            # build success payloads, so there's nothing safe to do here.
-            return  # type: ignore[unreachable]
-
         try:
             exception = kwargs.get("exception")
             error_info = {
@@ -41,16 +42,13 @@ class FailureAwareOpikLogger(OpikLogger):
                 "traceback": str(kwargs.get("traceback_exception") or ""),
                 "message": str(exception) if exception else "LLM call failed",
             }
-
             litellm_params = kwargs.get("litellm_params", {}) or {}
             litellm_metadata = litellm_params.get("metadata", {}) or {}
             standard_logging_object = kwargs.get("standard_logging_object", {}) or {}
             standard_logging_metadata = standard_logging_object.get("metadata", {}) or {}
-
             opik_metadata = extractors.extract_opik_metadata(litellm_metadata, standard_logging_metadata)
             current_span_data = opik_metadata.get("current_span_data")
             trace_id, parent_span_id = extractors.extract_span_identifiers(current_span_data)
-
             self._opik_client.span(
                 trace_id=trace_id,
                 parent_span_id=parent_span_id,
@@ -65,3 +63,56 @@ class FailureAwareOpikLogger(OpikLogger):
             )
         except Exception:
             logger.exception("FailureAwareOpikLogger failed to log failure event")
+
+
+def setup_trace(project_id: str, user_id: str, model: str | None, tags: list[str]) -> str | None:
+    trace_data = opik_context.get_current_trace_data()
+    opik_context.update_current_trace(
+        thread_id=project_id,
+        metadata={"model": model or "default", "user_id": user_id},
+        tags=[*tags, f"project:{project_id}"],
+    )
+    return trace_data.id if trace_data else None
+
+
+def set_trace_output(output: dict[str, Any]) -> None:
+    if opik_context.get_current_trace_data() is not None:
+        opik_context.update_current_trace(output=output)
+
+
+def create_span(**kwargs: Any) -> Span:
+    return get_global_client().span(**kwargs)
+
+
+def record_span_error(exc: Exception) -> None:
+    if opik_context.get_current_span_data() is not None:
+        opik_context.update_current_span(error_info=error_info(exc))
+
+
+def error_info(exc: Exception) -> ErrorInfoDict:
+    info: ErrorInfoDict = {
+        "exception_type": type(exc).__name__,
+        "traceback": "".join(traceback_module.format_exception(exc)),
+    }
+    message = str(exc)
+    if message:
+        info["message"] = message
+    return info
+
+
+def llm_metadata(
+    trace_id: str | None,
+    generation_name: str,
+    parent_span_id: str | None = None,
+    extra_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    span_data = opik_context.get_current_span_data()
+    resolved_trace_id = trace_id or (span_data.trace_id if span_data else None)
+    resolved_parent_span_id = parent_span_id or (span_data.id if span_data else None)
+    opik_meta: dict[str, Any] = {
+        "current_span_data": {"trace_id": resolved_trace_id, "id": resolved_parent_span_id},
+        "generation_name": generation_name,
+    }
+    if extra_metadata:
+        opik_meta.update(extra_metadata)
+    return {"opik": opik_meta}

--- a/backend/src/flow44/ai/core/opik_failure_logger.py
+++ b/backend/src/flow44/ai/core/opik_failure_logger.py
@@ -75,6 +75,11 @@ def setup_trace(project_id: str, user_id: str, model: str | None, tags: list[str
     return trace_data.id if trace_data else None
 
 
+def set_trace_input(input_data: dict[str, Any]) -> None:
+    if opik_context.get_current_trace_data() is not None:
+        opik_context.update_current_trace(input=input_data)
+
+
 def set_trace_output(output: dict[str, Any]) -> None:
     if opik_context.get_current_trace_data() is not None:
         opik_context.update_current_trace(output=output)

--- a/backend/src/flow44/ai/core/react_flow.py
+++ b/backend/src/flow44/ai/core/react_flow.py
@@ -71,21 +71,11 @@ class ReActFlow(Flow[StateT], Generic[StateT]):
             {"name": s["function"]["name"], "description": s["function"]["description"]} for s in tool_schemas
         ]
         last_content = ""
-        # Tool calls executed in the previous iteration, keyed by call id — so the next LLM
-        # call's span metadata can show "which tool + args produced this result" instead of
-        # leaving the tool-role messages as bare, unlabeled `tool_call_id` references.
-        last_tool_calls: dict[str, dict[str, Any]] = {}
 
         for iteration in range(self.max_iterations):
             # Call LLM with tools
             metadata = (
-                metadata_fn(
-                    f"react-{iteration}",
-                    extra_metadata={
-                        "available_tools": available_tools,
-                        "previous_tool_calls": list(last_tool_calls.values()) or None,
-                    },
-                )
+                metadata_fn(f"react-{iteration}", extra_metadata={"available_tools": available_tools})
                 if metadata_fn
                 else None
             )
@@ -136,8 +126,6 @@ class ReActFlow(Flow[StateT], Generic[StateT]):
             # Add assistant message with tool calls
             working_messages.append(message.model_dump())
 
-            last_tool_calls = {}
-
             # Execute each tool call
             for tool_call in message.tool_calls:
                 tool_name = tool_call.function.name
@@ -183,14 +171,6 @@ class ReActFlow(Flow[StateT], Generic[StateT]):
                         "content": result_str,
                     }
                 )
-
-                # Track for the next LLM call's span metadata (see `previous_tool_calls` above)
-                last_tool_calls[tool_call.id] = {
-                    "tool": tool_name,
-                    "args": args,
-                    "is_error": result.is_error,
-                    "result_preview": result_str[:500],
-                }
 
         logger.warning("[%s] Hit max iterations (%d)", self.name, self.max_iterations)
         return last_content

--- a/backend/src/flow44/ai/core/react_flow.py
+++ b/backend/src/flow44/ai/core/react_flow.py
@@ -67,15 +67,12 @@ class ReActFlow(Flow[StateT], Generic[StateT]):
         """
         working_messages: list[dict[str, Any]] = [m.to_dict() for m in messages]
         tool_schemas = tools.get_schemas()
-        available_tools = [
-            {"name": s["function"]["name"], "description": s["function"]["description"]} for s in tool_schemas
-        ]
         last_content = ""
 
         for iteration in range(self.max_iterations):
             # Call LLM with tools
             metadata = (
-                metadata_fn(f"react-{iteration}", extra_metadata={"available_tools": available_tools})
+                metadata_fn(f"react-{iteration}", extra_metadata={"available_tools": tool_schemas})
                 if metadata_fn
                 else None
             )

--- a/backend/src/flow44/ai/core/react_flow.py
+++ b/backend/src/flow44/ai/core/react_flow.py
@@ -67,11 +67,28 @@ class ReActFlow(Flow[StateT], Generic[StateT]):
         """
         working_messages: list[dict[str, Any]] = [m.to_dict() for m in messages]
         tool_schemas = tools.get_schemas()
+        available_tools = [
+            {"name": s["function"]["name"], "description": s["function"]["description"]} for s in tool_schemas
+        ]
         last_content = ""
+        # Tool calls executed in the previous iteration, keyed by call id — so the next LLM
+        # call's span metadata can show "which tool + args produced this result" instead of
+        # leaving the tool-role messages as bare, unlabeled `tool_call_id` references.
+        last_tool_calls: dict[str, dict[str, Any]] = {}
 
         for iteration in range(self.max_iterations):
             # Call LLM with tools
-            metadata = metadata_fn(f"react-{iteration}") if metadata_fn else None
+            metadata = (
+                metadata_fn(
+                    f"react-{iteration}",
+                    extra_metadata={
+                        "available_tools": available_tools,
+                        "previous_tool_calls": list(last_tool_calls.values()) or None,
+                    },
+                )
+                if metadata_fn
+                else None
+            )
 
             try:
                 logger.info(
@@ -119,6 +136,8 @@ class ReActFlow(Flow[StateT], Generic[StateT]):
             # Add assistant message with tool calls
             working_messages.append(message.model_dump())
 
+            last_tool_calls = {}
+
             # Execute each tool call
             for tool_call in message.tool_calls:
                 tool_name = tool_call.function.name
@@ -164,6 +183,14 @@ class ReActFlow(Flow[StateT], Generic[StateT]):
                         "content": result_str,
                     }
                 )
+
+                # Track for the next LLM call's span metadata (see `previous_tool_calls` above)
+                last_tool_calls[tool_call.id] = {
+                    "tool": tool_name,
+                    "args": args,
+                    "is_error": result.is_error,
+                    "result_preview": result_str[:500],
+                }
 
         logger.warning("[%s] Hit max iterations (%d)", self.name, self.max_iterations)
         return last_content

--- a/backend/src/flow44/ai/state.py
+++ b/backend/src/flow44/ai/state.py
@@ -20,7 +20,7 @@ class BuildState(BaseModel):
     generated_data_source_files: dict[str, str] = Field(default_factory=dict)
     architecture: ArchitectureDesign = Field(default_factory=ArchitectureDesign)
     ux_design: UXDesign = Field(default_factory=UXDesign)
-    user_overview: UserPlanOverview = Field(default_factory=UserPlanOverview)
+    user_plan_overview: UserPlanOverview = Field(default_factory=UserPlanOverview)
     work_plan: WorkPlan | None = None
     completed_files: dict[str, str] = Field(default_factory=dict)
     task_files: dict[str, list[str]] = Field(default_factory=dict)

--- a/backend/src/flow44/config.py
+++ b/backend/src/flow44/config.py
@@ -112,21 +112,22 @@ class LoggerSettings(Flow44BaseSettings):
     LOG_FILE_PATH: str | None = None
 
 
-class LangfuseSettings(Flow44BaseSettings):
-    # Langfuse (optional — set public/secret key to enable)
-    LANGFUSE_PUBLIC_KEY: str | None = None
-    LANGFUSE_SECRET_KEY: str | None = None
-    LANGFUSE_HOST: str = "https://cloud.langfuse.com"
-    LANGFUSE_TRACING_ENVIRONMENT: str | None = None
+class OpikSettings(Flow44BaseSettings):
+    # Opik (optional — set an API key to enable)
+    OPIK_API_KEY: str | None = None
+    OPIK_WORKSPACE: str | None = None
+    OPIK_PROJECT_NAME: str = "flow44"
+    OPIK_URL_OVERRIDE: str | None = None
 
     def model_post_init(self, __context: Any) -> None:
-        """Propagate Langfuse credentials to os.environ so the SDK can read them."""
-        if self.LANGFUSE_PUBLIC_KEY and self.LANGFUSE_SECRET_KEY:
-            os.environ["LANGFUSE_PUBLIC_KEY"] = self.LANGFUSE_PUBLIC_KEY
-            os.environ["LANGFUSE_SECRET_KEY"] = self.LANGFUSE_SECRET_KEY
-            os.environ["LANGFUSE_HOST"] = self.LANGFUSE_HOST
-            if self.LANGFUSE_TRACING_ENVIRONMENT:
-                os.environ["LANGFUSE_TRACING_ENVIRONMENT"] = self.LANGFUSE_TRACING_ENVIRONMENT
+        """Propagate Opik credentials to os.environ so the SDK can read them."""
+        if self.OPIK_API_KEY:
+            os.environ["OPIK_API_KEY"] = self.OPIK_API_KEY
+            if self.OPIK_WORKSPACE:
+                os.environ["OPIK_WORKSPACE"] = self.OPIK_WORKSPACE
+            os.environ["OPIK_PROJECT_NAME"] = self.OPIK_PROJECT_NAME
+            if self.OPIK_URL_OVERRIDE:
+                os.environ["OPIK_URL_OVERRIDE"] = self.OPIK_URL_OVERRIDE
 
 
 class Settings(
@@ -137,7 +138,7 @@ class Settings(
     AuthSettings,
     FlapiSettings,
     S3Settings,
-    LangfuseSettings,
+    OpikSettings,
     LoggerSettings,
     Flow44BaseSettings,
 ):

--- a/backend/src/flow44/main.py
+++ b/backend/src/flow44/main.py
@@ -1,13 +1,15 @@
+import asyncio
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 
 import litellm
+import opik
 from fastapi import APIRouter, Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from litellm.integrations.opik.opik import OpikLogger
 
+from flow44.ai.core.opik_failure_logger import FailureAwareOpikLogger
 from flow44.api import (
     admin,
     chat,
@@ -44,7 +46,7 @@ logger = logging.getLogger(__name__)
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     if settings.OPIK_API_KEY:
         # Credentials already in os.environ via OpikSettings.model_post_init
-        litellm.callbacks = [OpikLogger()]
+        litellm.callbacks = [FailureAwareOpikLogger()]
         logger.info("Opik tracing enabled")
     else:
         logger.info("Opik tracing not enabled (missing API key)")
@@ -74,6 +76,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await idle_reaper.stop()
     await heartbeat_reaper.stop()
     await sandbox_manager.suspend_all()
+    if settings.OPIK_API_KEY:
+        await asyncio.to_thread(opik.flush_tracker)
+        logger.info("Opik traces flushed.")
     logger.info("Shutdown complete.")
 
 

--- a/backend/src/flow44/main.py
+++ b/backend/src/flow44/main.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 import litellm
 from fastapi import APIRouter, Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from litellm.integrations.opik.opik import OpikLogger
 
 from flow44.api import (
     admin,
@@ -41,13 +42,12 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    if settings.LANGFUSE_PUBLIC_KEY and settings.LANGFUSE_SECRET_KEY:
-        # Credentials already in os.environ via LangfuseSettings.model_post_init
-        litellm.success_callback = ["langfuse"]
-        litellm.failure_callback = ["langfuse"]
-        logger.info("Langfuse tracing enabled")
+    if settings.OPIK_API_KEY:
+        # Credentials already in os.environ via OpikSettings.model_post_init
+        litellm.callbacks = [OpikLogger()]
+        logger.info("Opik tracing enabled")
     else:
-        logger.info("Langfuse tracing not enabled (missing keys)")
+        logger.info("Opik tracing not enabled (missing API key)")
 
     logger.info("Initialising database...")
     await init_db()

--- a/backend/src/flow44/sandbox/operations.py
+++ b/backend/src/flow44/sandbox/operations.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 
-from langfuse.decorators import observe
+from opik import track
 
 from flow44.config import settings
 from flow44.sandbox.manager import sandbox_manager
@@ -114,7 +114,7 @@ def _inline_favicon(html: str, dist_dir: str, workspace_dir: str) -> str:
     )
 
 
-@observe(name="build-single-html")  # type: ignore[untyped-decorator]
+@track(name="build-single-html")  # type: ignore[untyped-decorator]
 async def build_single_html(project_id: str) -> str:
     """Build the project and return a single self-contained HTML string."""
     sandbox = await sandbox_manager.get_sandbox(project_id)

--- a/backend/tests/ai/agents/execute/test_execute_task_contract.py
+++ b/backend/tests/ai/agents/execute/test_execute_task_contract.py
@@ -37,11 +37,11 @@ class _RecordingSandbox:
 class _FakeSpan:
     id = "obs-1"
 
-    def end(self) -> None:
+    def end(self, **_kwargs: Any) -> None:
         return None
 
 
-class _FakeLangfuse:
+class _FakeOpik:
     def span(self, **_kwargs: Any) -> _FakeSpan:
         return _FakeSpan()
 
@@ -64,8 +64,8 @@ def _make_state(task: Task, sandbox: _RecordingSandbox) -> ExecutionState:
         project_id="p",
         sandbox_ref=sandbox,
         emit_fn=_noop_emit,
-        langfuse_client=_FakeLangfuse(),
-        llm_metadata_fn=lambda _name: {},
+        opik_client=_FakeOpik(),
+        llm_metadata_fn=lambda _name, **_kwargs: {},
     )
 
 

--- a/backend/tests/ai/agents/execute/test_execute_task_contract.py
+++ b/backend/tests/ai/agents/execute/test_execute_task_contract.py
@@ -34,18 +34,6 @@ class _RecordingSandbox:
         self.written.append((path, content))
 
 
-class _FakeSpan:
-    id = "obs-1"
-
-    def end(self, **_kwargs: Any) -> None:
-        return None
-
-
-class _FakeOpik:
-    def span(self, **_kwargs: Any) -> _FakeSpan:
-        return _FakeSpan()
-
-
 async def _noop_emit(_event: dict[str, Any]) -> None:
     return None
 
@@ -64,7 +52,6 @@ def _make_state(task: Task, sandbox: _RecordingSandbox) -> ExecutionState:
         project_id="p",
         sandbox_ref=sandbox,
         emit_fn=_noop_emit,
-        opik_client=_FakeOpik(),
         llm_metadata_fn=lambda _name, **_kwargs: {},
     )
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -203,15 +203,6 @@ wheels = [
 ]
 
 [[package]]
-name = "backoff"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
-]
-
-[[package]]
 name = "boto3"
 version = "1.40.61"
 source = { registry = "https://pypi.org/simple" }
@@ -223,6 +214,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ed/f9/6ef8feb52c3cce5ec3967a535a6114b57ac7949fd166b0f3090c2b06e4e5/boto3-1.40.61.tar.gz", hash = "sha256:d6c56277251adf6c2bdd25249feae625abe4966831676689ff23b4694dea5b12", size = 111535, upload-time = "2025-10-28T19:26:57.247Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/24/3bf865b07d15fea85b63504856e137029b6acbc73762496064219cdb265d/boto3-1.40.61-py3-none-any.whl", hash = "sha256:6b9c57b2a922b5d8c17766e29ed792586a818098efe84def27c8f582b33f898c", size = 139321, upload-time = "2025-10-28T19:26:55.007Z" },
+]
+
+[[package]]
+name = "boto3-stubs"
+version = "1.43.51"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore-stubs" },
+    { name = "types-s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/cb/052936e4efb898ba165333864bfa0c1f99b4431b48562f8b07863d53a64e/boto3_stubs-1.43.51.tar.gz", hash = "sha256:56177d149f918ef2caf38176b61e286400448152c70f08a50616c596e8a851db", size = 103200, upload-time = "2026-07-17T20:29:43.733Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/8e/f2266a4a4a480883500e4d31badc621524125a1124b8d7595a3b4d83227a/boto3_stubs-1.43.51-py3-none-any.whl", hash = "sha256:dc01e52a142c023f59cad0a68cc5f149c5c64b2d9ca6af1b0cbb7e08f405de18", size = 70961, upload-time = "2026-07-17T20:29:40.693Z" },
+]
+
+[package.optional-dependencies]
+bedrock-runtime = [
+    { name = "mypy-boto3-bedrock-runtime" },
 ]
 
 [[package]]
@@ -484,8 +493,8 @@ dependencies = [
     { name = "greenlet" },
     { name = "httpx" },
     { name = "jinja2" },
-    { name = "langfuse" },
     { name = "litellm" },
+    { name = "opik" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "python-json-logger" },
@@ -523,8 +532,8 @@ requires-dist = [
     { name = "greenlet", specifier = ">=3.3.2" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
-    { name = "langfuse", specifier = "==2.59.7" },
-    { name = "litellm", specifier = ">=1.55.10,<1.82.3" },
+    { name = "litellm", specifier = ">=1.55.10" },
+    { name = "opik", specifier = ">=2.1.32" },
     { name = "pydantic-settings", specifier = ">=2.7.1" },
     { name = "pyjwt", specifier = ">=2.12.1" },
     { name = "python-json-logger", specifier = ">=4.1.0" },
@@ -818,25 +827,6 @@ wheels = [
 ]
 
 [[package]]
-name = "langfuse"
-version = "2.59.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "backoff" },
-    { name = "httpx" },
-    { name = "idna" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/0e/8390bd3a4ad92ecb1ba0462ec8b7c7d328b2e2f31ae0e734bf2f50dbdc96/langfuse-2.59.7.tar.gz", hash = "sha256:f631981705177bf53d030d191397da9b864b99729a7273448afed10d76f78e23", size = 146608, upload-time = "2025-03-03T16:30:59.926Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/f3/420518b9003c997cdcb0a86473bf0c111181578a95565823c333cb58eb7b/langfuse-2.59.7-py3-none-any.whl", hash = "sha256:2c6890f5b842257173eb54d08f2890c7fd7617859a48b3914ef73f13a6514473", size = 260468, upload-time = "2025-03-03T16:30:57.426Z" },
-]
-
-[[package]]
 name = "librt"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -859,7 +849,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.82.2"
+version = "1.93.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -875,9 +865,10 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/12/010a86643f12ac0b004032d5927c260094299a84ed38b5ed20a8f8c7e3c4/litellm-1.82.2.tar.gz", hash = "sha256:f5f4c4049f344a88bf80b2e421bb927807687c99624515d7ff4152d533ec9dcb", size = 17353218, upload-time = "2026-03-13T21:24:24.5Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/e1/4f05ca4cbb4efb739c9e66a182ecd5c816bc05bf3665ec8e0fb4ab408379/litellm-1.93.0.tar.gz", hash = "sha256:140bf215e264c71601bca9c06d2436c5451bb59e1e195ea23fc2d3d87b6929ec", size = 15948866, upload-time = "2026-07-19T03:01:24.389Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/e4/87e3ca82a8bf6e6bfffb42a539a1350dd6ced1b7169397bd439ba56fde10/litellm-1.82.2-py3-none-any.whl", hash = "sha256:641ed024774fa3d5b4dd9347f0efb1e31fa422fba2a6500aabedee085d1194cb", size = 15524224, upload-time = "2026-03-13T21:24:21.288Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/e1/eabe3f13d9c8b853a01377b59e78a295f34c24c36b09e5fc1c60c0167f19/litellm-1.93.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:23b8eea4fb8b3b6ade05e7b6085ec9ca12daffcfb38d033d0bbce9c1d5894da5", size = 20164863, upload-time = "2026-07-19T03:01:12.035Z" },
+    { url = "https://files.pythonhosted.org/packages/64/49/2db5757f7e284eb12618b547cb62dab49687ffaf1d749ca048210e3d0dbd/litellm-1.93.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:98c15e84d32e922a821c105308bf9ddae8700de9ed396530bee2cbb1cacf4cbb", size = 20157288, upload-time = "2026-07-19T03:01:15.395Z" },
 ]
 
 [[package]]
@@ -1019,6 +1010,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy-boto3-bedrock-runtime"
+version = "1.43.30"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/05/e9c80d2ad57066bca9f609dbe46d74586058c906ee488ca6698ca5020473/mypy_boto3_bedrock_runtime-1.43.30.tar.gz", hash = "sha256:e7f50e6cb125da7a0807c364ba6a8fcac67e01e5268aee97c62b92f75fd77049", size = 31280, upload-time = "2026-06-15T21:23:45.951Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/3e/f20d90c8b130dbd88cf12ec5b58cad075339ce70afac72105c1d8a353718/mypy_boto3_bedrock_runtime-1.43.30-py3-none-any.whl", hash = "sha256:bc73e6f824b87fca7e40528e272b119b12e770fc848db80f44567691f2aa136f", size = 37623, upload-time = "2026-06-15T21:23:39.868Z" },
+]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1044,6 +1044,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/88/15/52580c8fbc16d0675d516e8749806eda679b16de1e4434ea06fb6feaa610/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885", size = 676084, upload-time = "2026-03-25T22:08:59.96Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/9e/5bfa2270f902d5b92ab7d41ce0475b8630572e71e349b2a4996d14bdda93/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d", size = 1146656, upload-time = "2026-03-25T22:08:58.2Z" },
+]
+
+[[package]]
+name = "opik"
+version = "2.1.32"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3-stubs", extra = ["bedrock-runtime"] },
+    { name = "click" },
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "litellm" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pytest" },
+    { name = "rapidfuzz" },
+    { name = "rich" },
+    { name = "sentry-sdk" },
+    { name = "tenacity" },
+    { name = "tqdm" },
+    { name = "tree-sitter", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
+    { name = "tree-sitter-javascript", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
+    { name = "tree-sitter-typescript", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
+    { name = "uuid6" },
+    { name = "watchfiles" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/0a/2e3106bcca674f6a096848035999e9421f3a558b46f06310e25108336891/opik-2.1.32.tar.gz", hash = "sha256:0272c734608c03710b3f3dce2c5727dcfb97ee517ef8c690946db13d26b3ada4", size = 1176998, upload-time = "2026-07-17T08:07:13.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/52/3a4996eb91df6291e4c0cc575816d5e984e474eb7b87ca22a8063bcf5322/opik-2.1.32-py3-none-any.whl", hash = "sha256:ef2867d5d343884e30aa16b0005db3088472c49313c1d0506907a0a1c366b252", size = 1865089, upload-time = "2026-07-17T08:07:10.878Z" },
 ]
 
 [[package]]
@@ -1363,6 +1393,36 @@ wheels = [
 ]
 
 [[package]]
+name = "rapidfuzz"
+version = "3.14.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/21/ef6157213316e85790041254259907eb722e00b03480256c0545d98acd33/rapidfuzz-3.14.5.tar.gz", hash = "sha256:ba10ac57884ce82112f7ed910b67e7fb6072d8ef2c06e30dc63c0f604a112e0e", size = 57901753, upload-time = "2026-04-07T11:16:31.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/66/252803f2010ba699618cdc048b6e1f7cc1f433c08b4a9a17579b92ab0142/rapidfuzz-3.14.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ebd8fd343bf8492a1e60bcb6dc99f90f74f65d98d8241a6b3e1fed225b76ecd6", size = 1940205, upload-time = "2026-04-07T11:14:40.319Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/59/b2afd98e41af9cd54554a4c1c423d84cdd60e6b1c0a09496f033b55f60ec/rapidfuzz-3.14.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6737b35d5af7479c5bf9710f7b17edd9d2c43128d974d25fb4ea653e42c64609", size = 1159639, upload-time = "2026-04-07T11:14:42.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/7aa7e62c4c516a7af322ed0c4f0774208b72d457d0cfec808bad0df12f4a/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b002c7994cc9f2bc9d9856f0fbaee6e8072c983873846c92f25cefba5b2a925f", size = 1367194, upload-time = "2026-04-07T11:14:44.25Z" },
+    { url = "https://files.pythonhosted.org/packages/90/79/2fc252a63bc91d3c3b234d0a3a6ad4ebc460037a23cdcdaf9285f986e6c9/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17a34330cd2a538c1ce5d400b61ba358c5b72c654b928ff87b362e88f8b864c7", size = 3151805, upload-time = "2026-04-07T11:14:46.21Z" },
+    { url = "https://files.pythonhosted.org/packages/17/54/0c83508f2683ea70e2d05f8527eb07328acf7bb1e9d97a3bece5702378e7/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:95d937e74c1a7a1287dfb03b62a827be08ede10a155cf1af73bbf47f2b73ee6e", size = 1455667, upload-time = "2026-04-07T11:14:47.991Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1b/070175e873177814d58850a01ebe80e20ae11e93eb4da894d563988660fa/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:46b92a9970dcc34f0096901c792644094cab49554ac3547f35e3aebbdf0a3610", size = 2388246, upload-time = "2026-04-07T11:14:50.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/dd/77caf7aaf9c2be050ad1f128d7c24ff0f59079aa62c5f62f9df41c0af45e/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e012177c8e8a8a0754ae0d6027d63042aa5ff036d9f40f07cb3466a6082e21b8", size = 2494333, upload-time = "2026-04-07T11:14:52.303Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/dd7e1f2aa31a8fbbfc16b0610af1d770ffaf1287490f3c8c5b1c52da264f/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a2ae6f53f99c9a0eca7a0afc5b4e45fc73bc1dd4ac74c00509031d76df80ed98", size = 4258579, upload-time = "2026-04-07T11:14:54.538Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0a/ac99e1ba347ba0e85e0bb60b74231d55fb93c0eff43f2920ccb413d0be08/rapidfuzz-3.14.5-cp313-cp313-win32.whl", hash = "sha256:4a60f0057231188e3bd30216f7b4e0f279b11fa4ec818bb6c1d9f014d1562fbc", size = 1709231, upload-time = "2026-04-07T11:14:56.524Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cb/0e251d731b3166378644238e8f0cf9e89858c024e19f75ca9f7e3ae83fd5/rapidfuzz-3.14.5-cp313-cp313-win_amd64.whl", hash = "sha256:11bfc2ed8fbe4ab86bd516fadefab126f90e6dcadffa761739fcb304707dfd35", size = 1538519, upload-time = "2026-04-07T11:14:58.635Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/4548132acc947db6d5346a248e44a8b3a22d608ef30e770fb578caaf2d00/rapidfuzz-3.14.5-cp313-cp313-win_arm64.whl", hash = "sha256:b486b5218808f6f4dc471b114b1054e63553db69705c97da0271f47bd706aedd", size = 812628, upload-time = "2026-04-07T11:15:00.552Z" },
+    { url = "https://files.pythonhosted.org/packages/00/60/69b177577290c5eab892c6f75fe89c3aff3f9ae80298a78d9372b1cecb9a/rapidfuzz-3.14.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:39ef8658aaf67d51667e7bdaf7096f432333377d8302ac43c70b5df8a4cf89b8", size = 1970231, upload-time = "2026-04-07T11:15:02.603Z" },
+    { url = "https://files.pythonhosted.org/packages/48/38/2fd790052659cc4e2907b63c25433f0987864b445c1aeec1a302ef5ad948/rapidfuzz-3.14.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9ad37a0be705b544af6296da8edddc260d10a8ae5462530fc9991f66498bb1f9", size = 1194394, upload-time = "2026-04-07T11:15:04.572Z" },
+    { url = "https://files.pythonhosted.org/packages/80/f4/28430ad8472fc3536e8ebd51a864a226e979cfe924c6e3f83d111373aa74/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d45e06f60729e07d9b20c205f7e5cff90b6ef2584e852eecf46e045aea69627d", size = 1377051, upload-time = "2026-04-07T11:15:06.728Z" },
+    { url = "https://files.pythonhosted.org/packages/77/7e/9aeacabcfd1e77397968362e5b98fe14248b8307011136b17daf99752a8e/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e52da10236aa6212de71b9e170bace65b64b129c0dea7fc243d6c9ce976f5074", size = 3160565, upload-time = "2026-04-07T11:15:08.667Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f4/db4dd7be0cd2f2022117ac5407d905f435d60e48baaea313a567ad27e865/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:440d30faaf682ca496170a7f0cc5453ec942e3e079f0fd802c9a7f938dfb50a3", size = 1442113, upload-time = "2026-04-07T11:15:11.138Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/99/0e9f6aa57f3e32a767216f797e56dc96b720fcecfb9d8ee907ecc82f8d66/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:56227a61fd3d17b0cd9793132431f3a3d07c8654be96794ba9f89fe0fc8b2d09", size = 2396618, upload-time = "2026-04-07T11:15:13.154Z" },
+    { url = "https://files.pythonhosted.org/packages/60/94/44a78e39ffce17cbdd3e2b53b696acc751d5d153be0f499d052b07a4d904/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:2e83cd2e25bb4edd97b689d9979d9c3acccdaaf26ceac08212ceece202febcfa", size = 2478220, upload-time = "2026-04-07T11:15:15.193Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/df/454311469a09a507e9d784a35796742bec22e4cebe75551e2da4e0e290fd/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:af3b859726cd3374287e405e14b9634563c078c5531a4f62375508addebddad1", size = 4265027, upload-time = "2026-04-07T11:15:17.28Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/01/175465a9ab3e3b70ba669058372f009d1d49c1746e2dcd56b69df188d3a5/rapidfuzz-3.14.5-cp313-cp313t-win32.whl", hash = "sha256:8ce1d850b3c0178440efde9e884d98421b5e87ff925f364d6d79e23910d7593f", size = 1766814, upload-time = "2026-04-07T11:15:19.687Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a0/a9b84a47af06ebed94a1439eb2f02adebfb8628bcd30af1fe3e02f5ef56c/rapidfuzz-3.14.5-cp313-cp313t-win_amd64.whl", hash = "sha256:c84af70bcf34e99aee894e46a0f1ac77f17d0ef828179c387407642e2466d28a", size = 1582448, upload-time = "2026-04-07T11:15:21.98Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f1/5937800238b3f8248e70860d79f69ba8f73e764fff47e36bc9e2f26dbcc6/rapidfuzz-3.14.5-cp313-cp313t-win_arm64.whl", hash = "sha256:aac0ad28c686a5e72b81668b906c030ee28050b244544b8af68e12fb32543895", size = 832932, upload-time = "2026-04-07T11:15:24.358Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1518,6 +1578,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.66.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/ff/670abe04c5072719b5060ed93851d0d69525d60f8f2c5810f8becd58f9c1/sentry_sdk-2.66.0.tar.gz", hash = "sha256:9727d35aa83c56cd53294676fe65b96296a334c9ce107fa2142bd70f47acb265", size = 935745, upload-time = "2026-07-16T12:42:04.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/bb/49b10783f29067da2eec179320617e94faf63196609de47aeab3c26c3325/sentry_sdk-2.66.0-py3-none-any.whl", hash = "sha256:096136c214c602be2b323524d30755dc5b30ec5a218a206207f33b12c05c6f11", size = 504769, upload-time = "2026-07-16T12:42:02.919Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1611,6 +1684,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
 name = "tiktoken"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1690,6 +1772,53 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/03/5600b84aff2e6c4fe80cfebb4063fe2f50299521befe5f6092ab8c082f4a/tree_sitter-0.26.0.tar.gz", hash = "sha256:b40c219edccc4564530c96f8f1556f6202b37cda964d1cbd7bd2b7e68b40a245", size = 191423, upload-time = "2026-06-30T12:14:27.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b0/465257cf8f972ad9f9812ec1cbaa8ec210ebebb601ade9a15881aa2436b4/tree_sitter-0.26.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ed0889dbed843ce45ede9f5169c0b2dea2222f12685844a03fadb81f12705867", size = 148893, upload-time = "2026-06-30T12:14:10.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/19d093e854b45e807fecfdd26105c266f43aeecc39c4dc97992a7074ad5a/tree_sitter-0.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6189c6c340c7384357711e3d92645e96bfb79f7a502f86de1ebdb23eb43f7dab", size = 140829, upload-time = "2026-06-30T12:14:11.626Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ee/87e74671ed63a837e7a1f17ab94aa3913871e033b27523d8e7b83d6f7ad0/tree_sitter-0.26.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8ff2e0750b7daa722302838356d7b65e303829b7eb73c915df127ddba115e1d1", size = 639334, upload-time = "2026-06-30T12:14:12.836Z" },
+    { url = "https://files.pythonhosted.org/packages/66/e7/f7e04cd9dff6b6ac0adf23922796fbc76accd4cf4bcda50542748d485679/tree_sitter-0.26.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7075ef857ef86f327dbb72d1e2574dda78db5754b3a1fca6506acd7fe5d561a7", size = 668102, upload-time = "2026-06-30T12:14:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/90/0bfb16b7894fea728c774a89d5af421a9368a2f913bbd4e8dcab7caaecfb/tree_sitter-0.26.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:26c996c1edfee86e977bb3f5462e74fcec0d0b0db1e85a3c475875763caa03be", size = 648560, upload-time = "2026-06-30T12:14:15.302Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/e6/0fe05ba396e9623b0ae40ccf34171336b8701ec8d7bd0ee9f5224d638665/tree_sitter-0.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:00289bfe7978f3e0dc0ce69813a20fa9f44ea4c100b3ec62043e5eb74ccfc3a2", size = 665121, upload-time = "2026-06-30T12:14:16.403Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/a944b1ca35bed6068dc84a9967aaf3049d8cc0b7a36179eea8787270a6ab/tree_sitter-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:93e220cab7e6a823efeb2046c49171427de92ef71c7c681c01820d14d8d3721f", size = 129615, upload-time = "2026-06-30T12:14:17.463Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ef/c7ca48293580d2249f36940c4eed5b4ddeb9ce75baf9a4ef30621987e0c7/tree_sitter-0.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:b31a8195d2f224224c530ac814632d98c1dcc123d227442c07c736e86b70d564", size = 116525, upload-time = "2026-06-30T12:14:18.53Z" },
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/e0/e63103c72a9d3dfd89a31e02e660263ad84b7438e5f44ee82e443e65bbde/tree_sitter_javascript-0.25.0.tar.gz", hash = "sha256:329b5414874f0588a98f1c291f1b28138286617aa907746ffe55adfdcf963f38", size = 132338, upload-time = "2025-09-01T07:13:44.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/df/5106ac250cd03661ebc3cc75da6b3d9f6800a3606393a0122eca58038104/tree_sitter_javascript-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b70f887fb269d6e58c349d683f59fa647140c410cfe2bee44a883b20ec92e3dc", size = 64052, upload-time = "2025-09-01T07:13:36.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/8f/6b4b2bc90d8ab3955856ce852cc9d1e82c81d7ab9646385f0e75ffd5b5d3/tree_sitter_javascript-0.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8264a996b8845cfce06965152a013b5d9cbb7d199bc3503e12b5682e62bb1de1", size = 66440, upload-time = "2025-09-01T07:13:37.962Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c4/7da74ecdcd8a398f88bd003a87c65403b5fe0e958cdd43fbd5fd4a398fcf/tree_sitter_javascript-0.25.0-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9dc04ba91fc8583344e57c1f1ed5b2c97ecaaf47480011b92fbeab8dda96db75", size = 99728, upload-time = "2025-09-01T07:13:38.755Z" },
+    { url = "https://files.pythonhosted.org/packages/96/c8/97da3af4796495e46421e9344738addb3602fa6426ea695be3fcbadbee37/tree_sitter_javascript-0.25.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:199d09985190852e0912da2b8d26c932159be314bc04952cf917ed0e4c633e6b", size = 106072, upload-time = "2025-09-01T07:13:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/13/be/c964e8130be08cc9bd6627d845f0e4460945b158429d39510953bbcb8fcc/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dfcf789064c58dc13c0a4edb550acacfc6f0f280577f1e7a00de3e89fc7f8ddc", size = 104388, upload-time = "2025-09-01T07:13:40.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/89/9b773dee0f8961d1bb8d7baf0a204ab587618df19897c1ef260916f318ec/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1b852d3aee8a36186dbcc32c798b11b4869f9b5041743b63b65c2ef793db7a54", size = 98377, upload-time = "2025-09-01T07:13:41.838Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/dc/d90cb1790f8cec9b4878d278ad9faf7c8f893189ce0f855304fd704fc274/tree_sitter_javascript-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:e5ed840f5bd4a3f0272e441d19429b26eedc257abe5574c8546da6b556865e3c", size = 62975, upload-time = "2025-09-01T07:13:42.828Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1f/f9eba1038b7d4394410f3c0a6ec2122b590cd7acb03f196e52fa57ebbe72/tree_sitter_javascript-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:622a69d677aa7f6ee2931d8c77c981a33f0ebb6d275aa9d43d3397c879a9bb0b", size = 61668, upload-time = "2025-09-01T07:13:43.803Z" },
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/fc/bb52958f7e399250aee093751e9373a6311cadbe76b6e0d109b853757f35/tree_sitter_typescript-0.23.2.tar.gz", hash = "sha256:7b167b5827c882261cb7a50dfa0fb567975f9b315e87ed87ad0a0a3aedb3834d", size = 773053, upload-time = "2024-11-11T02:36:11.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/95/4c00680866280e008e81dd621fd4d3f54aa3dad1b76b857a19da1b2cc426/tree_sitter_typescript-0.23.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3cd752d70d8e5371fdac6a9a4df9d8924b63b6998d268586f7d374c9fba2a478", size = 286677, upload-time = "2024-11-11T02:35:58.839Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/2f/1f36fda564518d84593f2740d5905ac127d590baf5c5753cef2a88a89c15/tree_sitter_typescript-0.23.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c7cc1b0ff5d91bac863b0e38b1578d5505e718156c9db577c8baea2557f66de8", size = 302008, upload-time = "2024-11-11T02:36:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2d/975c2dad292aa9994f982eb0b69cc6fda0223e4b6c4ea714550477d8ec3a/tree_sitter_typescript-0.23.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4b1eed5b0b3a8134e86126b00b743d667ec27c63fc9de1b7bb23168803879e31", size = 351987, upload-time = "2024-11-11T02:36:02.669Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d1/a71c36da6e2b8a4ed5e2970819b86ef13ba77ac40d9e333cb17df6a2c5db/tree_sitter_typescript-0.23.2-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e96d36b85bcacdeb8ff5c2618d75593ef12ebaf1b4eace3477e2bdb2abb1752c", size = 344960, upload-time = "2024-11-11T02:36:04.443Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/cb/f57b149d7beed1a85b8266d0c60ebe4c46e79c9ba56bc17b898e17daf88e/tree_sitter_typescript-0.23.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8d4f0f9bcb61ad7b7509d49a1565ff2cc363863644a234e1e0fe10960e55aea0", size = 340245, upload-time = "2024-11-11T02:36:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ab/dd84f0e2337296a5f09749f7b5483215d75c8fa9e33738522e5ed81f7254/tree_sitter_typescript-0.23.2-cp39-abi3-win_amd64.whl", hash = "sha256:3f730b66396bc3e11811e4465c41ee45d9e9edd6de355a58bbbc49fa770da8f9", size = 278015, upload-time = "2024-11-11T02:36:07.631Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e4/81f9a935789233cf412a0ed5fe04c883841d2c8fb0b7e075958a35c65032/tree_sitter_typescript-0.23.2-cp39-abi3-win_arm64.whl", hash = "sha256:05db58f70b95ef0ea126db5560f3775692f609589ed6f8dd0af84b7f19f1cbb7", size = 274052, upload-time = "2024-11-11T02:36:09.514Z" },
 ]
 
 [[package]]
@@ -1779,6 +1908,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uuid6"
+version = "2025.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/b7/4c0f736ca824b3a25b15e8213d1bcfc15f8ac2ae48d1b445b310892dc4da/uuid6-2025.0.1.tar.gz", hash = "sha256:cd0af94fa428675a44e32c5319ec5a3485225ba2179eefcf4c3f205ae30a81bd", size = 13932, upload-time = "2025-07-04T18:30:35.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/b2/93faaab7962e2aa8d6e174afb6f76be2ca0ce89fde14d3af835acebcaa59/uuid6-2025.0.1-py3-none-any.whl", hash = "sha256:80530ce4d02a93cdf82e7122ca0da3ebbbc269790ec1cb902481fa3e9cc9ff99", size = 6979, upload-time = "2025-07-04T18:30:34.001Z" },
 ]
 
 [[package]]

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -87,7 +87,7 @@ export function ChatMessage({ message, isStreaming }: ChatMessageProps) {
   // Agent card messages
   if (message.agentCard) {
     return (
-      <div className={`group flex flex-col w-full ${isUser ? 'items-start' : 'items-end'} animate-message-in`}>
+      <div className={`group flex flex-col w-full ${isUser ? 'items-end' : 'items-start'} animate-message-in`}>
         <AgentCardRenderer message={message} />
         {message.agentCard.type === 'error_fix_request' && timestamp}
       </div>
@@ -95,7 +95,7 @@ export function ChatMessage({ message, isStreaming }: ChatMessageProps) {
   }
 
   return (
-    <div className={`flex w-full ${isUser ? 'justify-end' : 'justify-start'} animate-message-in`}>
+    <div className={`group flex flex-col w-full ${isUser ? 'items-end' : 'items-start'} animate-message-in`}>
       <div
         className={`min-w-0 max-w-[85%] overflow-hidden px-3.5 py-2.5 rounded-xl text-sm leading-relaxed ${
           isUser ? 'bg-user-bubble border border-primary/30' : 'bg-assistant-bubble border border-border'

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -1,10 +1,10 @@
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import { useTranslation } from "react-i18next";
-import { FileText, TerminalSquare } from "lucide-react";
-import type { Message } from "../../types";
-import { formatClock } from "../../utils/formatTime";
-import { Badge } from "../ui/badge";
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { useTranslation } from 'react-i18next';
+import { FileText, TerminalSquare } from 'lucide-react';
+import type { Message } from '../../types';
+import { formatClock } from '../../utils/formatTime';
+import { Badge } from '../ui/badge';
 import {
   DataSourcesFetchedCard,
   DesignCompleteCard,
@@ -14,7 +14,7 @@ import {
   ErrorFixRequestCard,
   FixProgressCard,
   FollowUpProgress,
-} from "./cards";
+} from './cards';
 
 interface ChatMessageProps {
   message: Message;
@@ -25,54 +25,38 @@ function AgentCardRenderer({ message }: { message: Message }) {
   const card = message.agentCard!;
 
   switch (card.type) {
-    case "data_sources_fetched":
+    case 'data_sources_fetched':
       return <DataSourcesFetchedCard dataSources={card.dataSources} />;
-    case "design_complete":
-      return (
-        <DesignCompleteCard architecture={card.architecture} ux={card.ux} />
-      );
-    case "plan_overview":
+    case 'design_complete':
+      return <DesignCompleteCard architecture={card.architecture} ux={card.ux} />;
+    case 'plan_overview':
       return <PlanOverviewCard overview={card.overview} />;
-    case "task_progress":
+    case 'task_progress':
       return <TaskProgressCard tasks={card.tasks} />;
-    case "project_summary":
+    case 'project_summary':
       return <ProjectSummaryCard summary={card.summary} />;
-    case "error_fix_request":
-      return (
-        <ErrorFixRequestCard
-          errorMessage={card.errorMessage}
-          errorFile={card.errorFile}
-          errorLine={card.errorLine}
-          errorStack={card.errorStack}
-        />
-      );
-    case "fix_progress":
-      return (
-        <FixProgressCard
-          steps={card.steps}
-          content={message.content}
-          diffs={card.diffs}
-        />
-      );
-    case "followup_progress":
-      return (
-        <FollowUpProgress
-          steps={card.steps}
-          answer={card.answer}
-          filesChanged={card.filesChanged}
-          diffs={card.diffs}
-        />
-      );
+    case 'error_fix_request':
+      return <ErrorFixRequestCard
+        errorMessage={card.errorMessage}
+        errorFile={card.errorFile}
+        errorLine={card.errorLine}
+        errorStack={card.errorStack}
+      />;
+    case 'fix_progress':
+      return <FixProgressCard steps={card.steps} content={message.content} diffs={card.diffs} />;
+    case 'followup_progress':
+      return <FollowUpProgress
+        steps={card.steps}
+        answer={card.answer}
+        filesChanged={card.filesChanged}
+        diffs={card.diffs}
+      />;
     default:
       return null;
   }
 }
 
-function DataSourceBadges({
-  dataSources,
-}: {
-  dataSources: { id: number; name: string }[];
-}) {
+function DataSourceBadges({ dataSources }: { dataSources: { id: number; name: string }[] }) {
   return (
     <div className="flex flex-wrap gap-1 mb-1.5">
       {dataSources.map((ds) => (
@@ -88,14 +72,9 @@ function DataSourceBadges({
 
 export function ChatMessage({ message, isStreaming }: ChatMessageProps) {
   const { i18n } = useTranslation();
-  const isUser = message.role === "user";
+  const isUser = message.role === 'user';
 
-  if (
-    !message.content &&
-    !message.agentCard &&
-    !message.actions?.length &&
-    !isStreaming
-  ) {
+  if (!message.content && !message.agentCard && !message.actions?.length && !isStreaming) {
     return null;
   }
 
@@ -108,24 +87,18 @@ export function ChatMessage({ message, isStreaming }: ChatMessageProps) {
   // Agent card messages
   if (message.agentCard) {
     return (
-      <div
-        className={`group flex flex-col w-full ${isUser ? "justify-end" : "justify-start"} animate-message-in`}
-      >
+      <div className={`group flex flex-col w-full ${isUser ? 'items-start' : 'items-end'} animate-message-in`}>
         <AgentCardRenderer message={message} />
-        {message.agentCard.type === "error_fix_request" && timestamp}
+        {message.agentCard.type === 'error_fix_request' && timestamp}
       </div>
     );
   }
 
   return (
-    <div
-      className={`flex w-full ${isUser ? "justify-end" : "justify-start"} animate-message-in`}
-    >
+    <div className={`flex w-full ${isUser ? 'justify-end' : 'justify-start'} animate-message-in`}>
       <div
         className={`min-w-0 max-w-[85%] overflow-hidden px-3.5 py-2.5 rounded-xl text-sm leading-relaxed ${
-          isUser
-            ? "bg-user-bubble border border-primary/30"
-            : "bg-assistant-bubble border border-border"
+          isUser ? 'bg-user-bubble border border-primary/30' : 'bg-assistant-bubble border border-border'
         }`}
       >
         {isUser && message.dataSources && message.dataSources.length > 0 && (
@@ -142,10 +115,7 @@ export function ChatMessage({ message, isStreaming }: ChatMessageProps) {
                   const isInline = !className;
                   if (isInline) {
                     return (
-                      <code
-                        className="bg-background px-1.5 py-0.5 rounded text-[13px] font-mono break-all"
-                        {...props}
-                      >
+                      <code className="bg-background px-1.5 py-0.5 rounded text-[13px] font-mono break-all" {...props}>
                         {children}
                       </code>
                     );
@@ -170,21 +140,15 @@ export function ChatMessage({ message, isStreaming }: ChatMessageProps) {
         {message.actions && message.actions.length > 0 && (
           <div className="mt-2 flex flex-col gap-1">
             {message.actions.map((action, i) => (
-              <div
-                key={i}
-                className="flex items-center gap-1.5 text-xs text-muted-foreground px-2 py-1 bg-background rounded"
-              >
-                {action.type === "file" ? (
+              <div key={i} className="flex items-center gap-1.5 text-xs text-muted-foreground px-2 py-1 bg-background rounded">
+                {action.type === 'file' ? (
                   <>
                     <FileText size={14} className="text-primary shrink-0" />
                     <span className="truncate">{action.path}</span>
                   </>
                 ) : (
                   <>
-                    <TerminalSquare
-                      size={14}
-                      className="text-success shrink-0"
-                    />
+                    <TerminalSquare size={14} className="text-success shrink-0" />
                     <span className="truncate">{action.command}</span>
                   </>
                 )}

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -78,14 +78,14 @@ export function ChatMessage({ message, isStreaming }: ChatMessageProps) {
   // Agent card messages
   if (message.agentCard) {
     return (
-      <div className={`flex w-full ${isUser ? 'justify-start' : 'justify-end'} animate-message-in`}>
+      <div className={`flex w-full ${isUser ? 'justify-end' : 'justify-start'} animate-message-in`}>
         <AgentCardRenderer message={message} />
       </div>
     );
   }
 
   return (
-    <div className={`flex w-full ${isUser ? 'justify-start' : 'justify-end'} animate-message-in`}>
+    <div className={`flex w-full ${isUser ? 'justify-end' : 'justify-start'} animate-message-in`}>
       <div
         className={`min-w-0 max-w-[85%] overflow-hidden px-3.5 py-2.5 rounded-xl text-sm leading-relaxed ${
           isUser ? 'bg-user-bubble border border-primary/30' : 'bg-assistant-bubble border border-border'


### PR DESCRIPTION
## Summary
- Replace Langfuse with Opik across all agents (plan, execute, follow-up, fix-error): traces tag/thread by project id, manual execute-agent spans nest correctly under their parent step instead of flattening to the trace root, and LLM spans carry `available_tools` (name + description) and `previous_tool_calls` (tool/args/result of the prior iteration) for easier debugging in the Opik UI.
- Bump litellm past its old `<1.82.3` pin now that Opik's own version constraints (`!=1.81.*,!=1.82.*,...`) allow a newer resolution (1.80.17 → 1.93.0).
- Revert an unrelated PR (#128) that had swapped user/assistant chat bubble sides — restores user-right/assistant-left.

## Test plan
- [x] `mypy` / `ruff check` / `ruff format --check` all clean
- [x] Full backend test suite passes (496 tests)
- [x] Verified live against Opik Cloud: ran build → follow-up → fix-error flows end-to-end through the actual app UI, confirmed traces/spans land correctly with proper nesting, project tags, and tool-visibility metadata via the Opik API