### PR TITLE
chore: fix orphaned test DBs, expose minio ports, apply ruff autofixes

### DIFF
--- a/backend/tests/ai/agents/test_file_diffs.py
+++ b/backend/tests/ai/agents/test_file_diffs.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from flow44.ai.agents.file_diffs import DiffTracker, compute_diff
+from flow44.ai.agents.file_diffs import DiffTracker
 
 
 class TestDiffTracker:

--- a/backend/tests/api/test_data_source_api.py
+++ b/backend/tests/api/test_data_source_api.py
@@ -11,7 +11,7 @@ from flow44.logic import data_source as ds_logic
 
 class TestDataSourceAPI:
     async def test_run_maps_401_upstream(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        async def _fake_run(*_a, **_kw):  # noqa: ANN002, ANN003, ARG001
+        async def _fake_run(*_a, **_kw):
             raise ds_logic.FlapiUpstreamError("unauthorized", status_code=401)
 
         monkeypatch.setattr(ds_logic, "run_data_source", _fake_run)
@@ -25,7 +25,7 @@ class TestDataSourceAPI:
         assert exc.value.status_code == 401
 
     async def test_search_maps_500_to_502(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        async def _fake_search(*_a, **_kw):  # noqa: ANN002, ANN003, ARG001
+        async def _fake_search(*_a, **_kw):
             raise ds_logic.FlapiUpstreamError("FLAPI error (500)", status_code=500)
 
         monkeypatch.setattr(ds_logic, "search_data_sources", _fake_search)

--- a/backend/tests/api/test_files_api.py
+++ b/backend/tests/api/test_files_api.py
@@ -138,7 +138,7 @@ def test_upload_entry_writes_binary_and_conflict(tmp_path: Path) -> None:
 
 def test_search_entry_returns_matches(tmp_path: Path) -> None:
     class SearchSandbox(APITestSandbox):
-        async def grep(self, *args, **kwargs):  # type: ignore[override]  # noqa: ANN002, ANN003
+        async def grep(self, *args, **kwargs):  # type: ignore[override]
             return [GrepMatch(file="/src/types.ts", line=1, column=18, content="export interface Todo {")]
 
     info = SandboxInfo(project_id=PROJECT_ID, workspace_dir=str(tmp_path), port=0)
@@ -160,7 +160,7 @@ def test_search_entry_returns_matches(tmp_path: Path) -> None:
 
 def test_search_entry_returns_503_when_search_tool_is_unavailable(tmp_path: Path) -> None:
     class SearchUnavailableSandbox(APITestSandbox):
-        async def grep(self, *args, **kwargs):  # type: ignore[override]  # noqa: ANN002, ANN003
+        async def grep(self, *args, **kwargs):  # type: ignore[override]
             raise SearchToolError("ripgrep (rg) is required for search but was not found in PATH")
 
     info = SandboxInfo(project_id=PROJECT_ID, workspace_dir=str(tmp_path), port=0)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -76,7 +76,7 @@ async def setup_test_db():
         version="16",
         password=settings.DB_PASSWORD,
     )
-    # An aborted run never reaches __exit__, and init() has no IF NOT EXISTS
+    # Pre-drop the DB if it exists from prior aborted runs (suppresses error if it doesn't exist yet).
     with contextlib.suppress(psycopg.errors.InvalidCatalogName):
         janitor.drop()
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,11 +1,13 @@
+import contextlib
 import functools
 import os
 from pathlib import Path
 
-import pytest  # noqa: E402
+import psycopg
+import pytest
 from dotenv import load_dotenv
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine  # noqa: E402
-from sqlalchemy.pool import NullPool  # noqa: E402
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
 
 # Load test.env to satisfy required environment variables in tests
 # Must happen before importing flow44.config (which reads env vars)
@@ -13,7 +15,13 @@ load_dotenv(Path(__file__).parent / "test.env")
 
 import flow44.config  # noqa: E402
 import flow44.db.database  # noqa: E402
-from flow44.api.deps import TokenPayload, get_user_id, get_user_permissions, validate_token, validate_ws_token  # noqa: E402
+from flow44.api.deps import (  # noqa: E402
+    TokenPayload,
+    get_user_id,
+    get_user_permissions,
+    validate_token,
+    validate_ws_token,
+)
 from flow44.auth.permissions import get_owner_permissions  # noqa: E402
 from flow44.db.database import build_db_url, init_db, reset  # noqa: E402
 from flow44.main import app  # noqa: E402
@@ -60,14 +68,19 @@ async def setup_test_db():
     worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
     dbname = f"test_flow44_{worker}"
 
-    with DatabaseJanitor(
+    janitor = DatabaseJanitor(
         user=settings.DB_USER,
         host=settings.DB_HOST,
         port=settings.DB_PORT,
         dbname=dbname,
         version="16",
         password=settings.DB_PASSWORD,
-    ):
+    )
+    # An aborted run never reaches __exit__, and init() has no IF NOT EXISTS
+    with contextlib.suppress(psycopg.errors.InvalidCatalogName):
+        janitor.drop()
+
+    with janitor:
         settings.DB_NAME = dbname
         await reset()
         await init_db()

--- a/backend/tests/integrations/flapi/test_models.py
+++ b/backend/tests/integrations/flapi/test_models.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import pytest
+
 from flow44.integrations.flapi.models import PackageMetadata, QuickParamsInfo
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/logic/test_can_run_without_params.py
+++ b/backend/tests/logic/test_can_run_without_params.py
@@ -14,7 +14,7 @@ class TestCanRunWithoutParams:
     async def test_no_params_can_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Data source with no params can run."""
 
-        async def _fake_get_params(*_a, **_kw):  # noqa: ANN001, ANN002, ANN003, ARG001
+        async def _fake_get_params(*_a, **_kw):
             return DataSourceParamsInfo(parameters=[], require_any=False)
 
         monkeypatch.setattr(ds_logic, "get_params_info", _fake_get_params)
@@ -27,7 +27,7 @@ class TestCanRunWithoutParams:
     async def test_all_optional_params_can_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Data source with only optional params can run."""
 
-        async def _fake_get_params(*_a, **_kw):  # noqa: ANN001, ANN002, ANN003, ARG001
+        async def _fake_get_params(*_a, **_kw):
             return DataSourceParamsInfo(
                 parameters=[
                     ParamDefinition(
@@ -53,7 +53,7 @@ class TestCanRunWithoutParams:
     async def test_required_param_with_default_can_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Data source with required param that has default value can run."""
 
-        async def _fake_get_params(*_a, **_kw):  # noqa: ANN001, ANN002, ANN003, ARG001
+        async def _fake_get_params(*_a, **_kw):
             return DataSourceParamsInfo(
                 parameters=[
                     ParamDefinition(
@@ -82,7 +82,7 @@ class TestCanRunWithoutParams:
     async def test_required_param_without_options_cannot_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Data source with required param but no default values cannot run."""
 
-        async def _fake_get_params(*_a, **_kw):  # noqa: ANN001, ANN002, ANN003, ARG001
+        async def _fake_get_params(*_a, **_kw):
             return DataSourceParamsInfo(
                 parameters=[
                     ParamDefinition(
@@ -107,7 +107,7 @@ class TestCanRunWithoutParams:
     async def test_mixed_params_with_defaults_can_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Data source with mix of optional and required (with defaults) can run."""
 
-        async def _fake_get_params(*_a, **_kw):  # noqa: ANN001, ANN002, ANN003, ARG001
+        async def _fake_get_params(*_a, **_kw):
             return DataSourceParamsInfo(
                 parameters=[
                     ParamDefinition(
@@ -142,7 +142,7 @@ class TestCanRunWithoutParams:
     async def test_integer_param_converted(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Integer type params are converted to int."""
 
-        async def _fake_get_params(*_a, **_kw):  # noqa: ANN001, ANN002, ANN003, ARG001
+        async def _fake_get_params(*_a, **_kw):
             return DataSourceParamsInfo(
                 parameters=[
                     ParamDefinition(
@@ -169,7 +169,7 @@ class TestCanRunWithoutParams:
     async def test_boolean_param_converted(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Boolean type params are converted to bool."""
 
-        async def _fake_get_params(*_a, **_kw):  # noqa: ANN001, ANN002, ANN003, ARG001
+        async def _fake_get_params(*_a, **_kw):
             return DataSourceParamsInfo(
                 parameters=[
                     ParamDefinition(
@@ -196,7 +196,7 @@ class TestCanRunWithoutParams:
     async def test_invalid_integer_cannot_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """If integer param value cannot be parsed, cannot run."""
 
-        async def _fake_get_params(*_a, **_kw):  # noqa: ANN001, ANN002, ANN003, ARG001
+        async def _fake_get_params(*_a, **_kw):
             return DataSourceParamsInfo(
                 parameters=[
                     ParamDefinition(
@@ -221,7 +221,7 @@ class TestCanRunWithoutParams:
     async def test_require_any_with_defaults_can_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Data source with RequireAny where at least one has default can run."""
 
-        async def _fake_get_params(*_a, **_kw):  # noqa: ANN001, ANN002, ANN003, ARG001
+        async def _fake_get_params(*_a, **_kw):
             return DataSourceParamsInfo(
                 parameters=[
                     ParamDefinition(
@@ -258,7 +258,7 @@ class TestCanRunWithoutParams:
     async def test_multi_value_required_param_emits_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """is_single_value=False on a required param yields a one-element list default."""
 
-        async def _fake_get_params(*_a, **_kw):  # noqa: ANN001, ANN002, ANN003, ARG001
+        async def _fake_get_params(*_a, **_kw):
             return DataSourceParamsInfo(
                 parameters=[
                     ParamDefinition(
@@ -287,7 +287,7 @@ class TestCanRunWithoutParams:
     async def test_multi_value_require_any_emits_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Multi-value require_any group default is also wrapped in a list."""
 
-        async def _fake_get_params(*_a, **_kw):  # noqa: ANN001, ANN002, ANN003, ARG001
+        async def _fake_get_params(*_a, **_kw):
             return DataSourceParamsInfo(
                 parameters=[
                     ParamDefinition(
@@ -314,7 +314,7 @@ class TestCanRunWithoutParams:
     async def test_require_any_without_defaults_cannot_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Data source with RequireAny where none have defaults cannot run."""
 
-        async def _fake_get_params(*_a, **_kw):  # noqa: ANN001, ANN002, ANN003, ARG001
+        async def _fake_get_params(*_a, **_kw):
             return DataSourceParamsInfo(
                 parameters=[
                     ParamDefinition(

--- a/backend/tests/logic/test_get_usage.py
+++ b/backend/tests/logic/test_get_usage.py
@@ -55,7 +55,7 @@ class TestGetUsage:
             AsyncMock(return_value=_metadata(queries=[_query("persons")])),
         )
 
-        async def _fake_params(*_a, **_kw):  # noqa: ANN001, ANN002, ANN003, ARG001
+        async def _fake_params(*_a, **_kw):
             return DataSourceParamsInfo(parameters=[], require_any=False)
 
         monkeypatch.setattr(ds_logic, "get_params_info", _fake_params)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,6 +135,9 @@ services:
     networks:
       - internal
     restart: unless-stopped
+    ports:
+      - "9000:9000"
+      - "9001:9001"
 
 networks:
   internal:


### PR DESCRIPTION
Small unrelated fixes pulled out of a feature branch.

**Orphaned test DBs.** `DatabaseJanitor.init()` does a bare `CREATE DATABASE` while `drop()` uses `IF EXISTS`, so an aborted pytest run leaves `test_flow44_<worker>` behind and every later run fails that worker with `DuplicateDatabase`. Three orphans were breaking 41 tests locally. Now drops before creating, suppressing `InvalidCatalogName` when absent (`drop()` can't be called unguarded — it does `ALTER DATABASE` first).

**Minio ports.** Published 9000/9001 to the host for local dev.

**Ruff autofixes.** Six test files + conftest imports. Mechanical; they were being reapplied every run.
