### PR TITLE
fix: reduce first-build failures from timeouts and JSX in .ts files

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,6 +19,10 @@ AIB_AI_MODEL=qwen/qwen3-coder-30b-a3b-instruct
 AIB_AI_BASE_URL=http://flow-44-models.com/openai/v1
 AIB_AI_API_KEY=default
 
+# Timeouts (seconds)
+# AIB_AI_REQUEST_TIMEOUT=300        # non-streaming calls (plan / summary / followup)
+# AIB_AI_STREAM_TIMEOUT=600         # streaming calls (codegen / fix loop)
+
 # For OpenRouter:
 # AIB_AI_MODEL=minimax/minimax-m2.5
 # AIB_AI_BASE_URL=https://openrouter.ai/api/v1

--- a/backend/src/flow44/ai/agents/execute/templates/codegen.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/codegen.jinja2
@@ -121,5 +121,6 @@ placeholders or ellipses.
 6. **CRITICAL**: Only React, TypeScript, and Tailwind CSS are available. Do NOT use or import other npm packages (no axios, lodash, zustand, date-fns, clsx, etc.). All functionality must be implemented using built-in browser APIs and the pre-installed packages only.
 7. Import from already-completed files using their exact export names.
 8. Do NOT include shell actions — only file actions.
+9. Any file containing JSX must use the `.tsx` extension; `.ts` is for pure TypeScript only. If a file listed above has a `.ts` extension, its contents must contain no JSX.
 
 {% include "_file_safety_rules.jinja2" %}

--- a/backend/src/flow44/ai/agents/execute/templates/merge.jinja2
+++ b/backend/src/flow44/ai/agents/execute/templates/merge.jinja2
@@ -40,6 +40,7 @@ Rules:
 - Do NOT create tasks for modifying package.json - only the pre-configured packages are available (React, TypeScript, Vite, Tailwind CSS)
 - Do NOT include tasks for installing dependencies or running the dev server
 - Do NOT include `src/config.ts` in any task's files — it is pre-configured and must not be overwritten
+- Any file containing JSX (a React component, or a hook that returns JSX) MUST be named `.tsx`; use `.ts` only for pure TypeScript with no JSX (types, constants, non-JSX utilities and hooks). A `.ts` file containing JSX will not compile and cannot be renamed later
 
 {% include "_file_safety_rules.jinja2" %}
 {% if has_data_sources %}

--- a/backend/src/flow44/ai/agents/plan/templates/architecture.jinja2
+++ b/backend/src/flow44/ai/agents/plan/templates/architecture.jinja2
@@ -24,6 +24,7 @@ Rules:
 - Use Tailwind CSS for styling
 - Keep it simple — prefer useState/useReducer over external state libraries unless complexity warrants it
 - All file paths are relative to the project root (e.g. src/App.tsx)
+- Any file containing JSX (a React component, or a hook that returns JSX) MUST be named `.tsx`; use `.ts` only for pure TypeScript with no JSX (types, constants, non-JSX utilities and hooks). A `.ts` file containing JSX will not compile and cannot be renamed later
 - Include only the files that need to be created or modified
 - **CRITICAL**: ONLY use the pre-installed packages (react, react-dom, @types/react, @types/react-dom, typescript, vite, tailwindcss, autoprefixer, postcss). Do NOT suggest adding other packages or dependencies. All functionality must be implemented using built-in browser APIs and these pre-configured packages only.
 

--- a/backend/src/flow44/ai/core/provider.py
+++ b/backend/src/flow44/ai/core/provider.py
@@ -112,7 +112,7 @@ async def stream_chat(
             api_base=settings.AI_BASE_URL,
             api_key=settings.AI_API_KEY,
             stream=True,
-            timeout=settings.AI_REQUEST_TIMEOUT,
+            timeout=settings.AI_STREAM_TIMEOUT,
             metadata=metadata or {},
         )
 

--- a/backend/src/flow44/config.py
+++ b/backend/src/flow44/config.py
@@ -62,6 +62,7 @@ class AIModelSettings(BuildAppSettings):
     AI_BASE_URL: str | None = "http://flow-44-models.com/openai/v1"
     AI_API_KEY: str | None = "default"
     AI_REQUEST_TIMEOUT: int = 300
+    AI_STREAM_TIMEOUT: int = 600  # kept well under AGENT_RUN_TIMEOUT, which spans every layer of a run
 
     # if ai_model starts with bedrock/ set base_url and api_key to None
     # (using pydantic v2's model_validator to allow dynamic defaults based on other fields)

--- a/backend/src/flow44/config.py
+++ b/backend/src/flow44/config.py
@@ -62,7 +62,7 @@ class AIModelSettings(BuildAppSettings):
     AI_BASE_URL: str | None = "http://flow-44-models.com/openai/v1"
     AI_API_KEY: str | None = "default"
     AI_REQUEST_TIMEOUT: int = 300
-    AI_STREAM_TIMEOUT: int = 600  # kept well under AGENT_RUN_TIMEOUT, which spans every layer of a run
+    AI_STREAM_TIMEOUT: int = 600
 
     # if ai_model starts with bedrock/ set base_url and api_key to None
     # (using pydantic v2's model_validator to allow dynamic defaults based on other fields)

--- a/backend/tests/ai/core/test_provider.py
+++ b/backend/tests/ai/core/test_provider.py
@@ -1,0 +1,42 @@
+"""Tests for stream_chat."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any
+
+import litellm
+import pytest
+
+from flow44.ai.core.provider import stream_chat
+from flow44.config import settings
+
+_MESSAGES = [{"role": "user", "content": "go"}]
+
+
+def _chunk(content: str) -> SimpleNamespace:
+    return SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content=content))])
+
+
+def _fake_acompletion(count: int) -> tuple[Any, dict[str, Any]]:
+    seen: dict[str, Any] = {}
+
+    async def _stream() -> AsyncIterator[SimpleNamespace]:
+        for i in range(count):
+            yield _chunk(str(i))
+
+    async def _acompletion(**kwargs: Any) -> AsyncIterator[SimpleNamespace]:
+        seen.update(kwargs)
+        return _stream()
+
+    return _acompletion, seen
+
+
+async def test_stream_yields_every_chunk_and_uses_the_stream_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    acompletion, seen = _fake_acompletion(count=3)
+    monkeypatch.setattr(litellm, "acompletion", acompletion)
+
+    assert [chunk async for chunk in stream_chat(_MESSAGES, "sys")] == ["0", "1", "2"]
+    assert seen["timeout"] == settings.AI_STREAM_TIMEOUT
+    assert seen["timeout"] != settings.AI_REQUEST_TIMEOUT

--- a/backend/tests/ai/test_prompts.py
+++ b/backend/tests/ai/test_prompts.py
@@ -149,6 +149,22 @@ class TestPromptRendering:
         assert "dataSourceAnalytics" in result
         assert "pre-generated" in result.lower()
 
+    def test_jsx_files_must_be_named_tsx(self) -> None:
+        rendered = [
+            render_architecture(),
+            render_merge(),
+            render_codegen(
+                task_title="Create Header",
+                task_description="Build the header component",
+                task_files=["src/Header.tsx"],
+                architecture={},
+                ux_design={},
+            ),
+        ]
+        for result in rendered:
+            assert "`.tsx`" in result
+            assert "JSX" in result
+
     def test_fix_prompts_include_file_safety_rules_once(self) -> None:
         execute_fix = render_feedback(files={"src/App.tsx": "broken"})
         direct_fix = render_fix_error_direct(error_message="broken", files={"src/App.tsx": "broken"})


### PR DESCRIPTION
57.6% of generated miniapps fail their first build (33 prod traces, Opik `flow44`). Two causes, both fixed here.

**Streaming timeout.** `stream_chat` passed `AI_REQUEST_TIMEOUT` (300s) to a streaming call as a total cap, so generations still producing tokens got killed. Failed tasks leave files unwritten, and dependents then import paths that never exist. Adds `AI_STREAM_TIMEOUT = 600` for the streaming path only; 300s stays for the non-streaming paths. Capped at 600 because `AGENT_RUN_TIMEOUT` (1800) covers all layers of a run.

**JSX in `.ts`.** No prompt stated a `.ts`/`.tsx` rule. Vite resolves `.ts` before `.tsx` and the parser has no rename/delete, so the fixer's corrected `.tsx` stays shadowed — one trace burned all 10 attempts. The extension is chosen by the planner (`architecture` → `merge` → `task.files`), so the rule goes there, plus `codegen` as a backstop.

Narrows the timeout window rather than closing it — past 600s the same failure mode returns. Residual-failure handling, npm EACCES, and vite `resolve.extensions` are out of scope.

**Tests:** `pytest tests/ai` 150 passed; ruff + mypy clean. The new provider test asserts the stream timeout is used and not `AI_REQUEST_TIMEOUT`, so it fails on revert.
