### PR TITLE
Keep sandbox runtime artifacts out of the project template's git

### DIFF
--- a/backend/pnpm-project-template/.gitignore
+++ b/backend/pnpm-project-template/.gitignore
@@ -3,3 +3,6 @@ dist
 dist-ssr
 *.local
 .DS_Store
+.npmrc
+.bashrc
+.*.log

--- a/backend/pnpm-project-template/.gitignore
+++ b/backend/pnpm-project-template/.gitignore
@@ -3,6 +3,5 @@ dist
 dist-ssr
 *.local
 .DS_Store
-.npmrc
 .bashrc
 .*.log

--- a/backend/src/flow44/ai/file_safety.py
+++ b/backend/src/flow44/ai/file_safety.py
@@ -26,6 +26,8 @@ _PROTECTED_APP_FILE_PATHS: tuple[str, ...] = (
 )
 
 _PROTECTED_APP_FILE_PATTERNS: tuple[str, ...] = (
+    "**/.git/**",
+    "**/.gitignore",
     "src/api/**",
     "src/auth/**",
     "src/platform/**",
@@ -42,6 +44,7 @@ _PROTECTED_APP_FILE_PATTERNS: tuple[str, ...] = (
 # Protected paths that can diverge per project.
 _SYNC_EXCLUDED_PATTERNS: frozenset[str] = frozenset(
     {
+        "**/.git/**",
         "**/index.html",
         "**/package.json",
         "**/pnpm-lock.yaml",

--- a/backend/tests/ai/test_file_safety.py
+++ b/backend/tests/ai/test_file_safety.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from flow44.ai.file_safety import (
+    SYNCABLE_TEMPLATE_FILE_PATTERNS,
     FileSafetyError,
     format_rejection_feedback,
     normalized_path_or_reject,
@@ -25,6 +26,9 @@ from flow44.ai.file_safety import (
         "src/main.tsx",
         "src/vite-env.d.ts",
         "src/platform/internal/README.md",
+        ".git/hooks/post-checkout",
+        ".git/config",
+        ".gitignore",
     ],
 )
 def test_protected_generated_app_files_are_rejected(path: str) -> None:
@@ -109,3 +113,12 @@ def test_file_safety_prompt_context_uses_contract_values() -> None:
     assert "**/package.json" in context["protected_patterns"]
     assert "src/platform/**" in context["protected_patterns"]
     assert "**/vite.config.*" in context["protected_patterns"]
+
+
+def test_gitignore_syncs_from_the_template() -> None:
+    # Projects predating a template ignore rule must pick it up, or the dev server log lands in git.
+    assert "**/.gitignore" in SYNCABLE_TEMPLATE_FILE_PATTERNS
+
+
+def test_git_internals_never_sync_from_the_template() -> None:
+    assert "**/.git/**" not in SYNCABLE_TEMPLATE_FILE_PATTERNS


### PR DESCRIPTION
Split out of `shalom/versioning`, which puts a real git repo inside each project workspace. Before that lands, the scaffolded template needs to stop leaking sandbox runtime artifacts into git.

## What the sandbox writes into a workspace

| Artifact | Written by |
| --- | --- |
| `.dev-server.log`, `.nsjail.log` | `base.py:129` (`get_background_log_path`), `namespaced.py:82` |
| `.npmrc` (registry + store-dir, env-specific) | `pnpm_mixin.py:22` (`configure_npmrc`) |
| `.bashrc` | `unix_local.py:27` |
| `.env.production.local` | `operations.py:126` — already matched by the existing `*.local` |

`.*.log` covers the `.{name}.log` convention, so future background processes are handled without another edit.

## Existing projects

A template change alone doesn't reach projects that already exist. `template_sync.py` already solves this — it overwrites a project's copy of any file matching `SYNCABLE_TEMPLATE_FILE_PATTERNS`, driven by `POST /admin/maintenance/sync-protected-files`. That set is derived from the protected-file lists, so adding `**/.gitignore` to `_PROTECTED_APP_FILE_PATTERNS` makes it both un-editable by the agents and auto-synced to older workspaces. No new machinery.

`**/.git/**` is protected too, but added to `_SYNC_EXCLUDED_PATTERNS`: git internals are never "safe to overwrite verbatim from the template". It's a no-op today since `_get_template_file_paths_to_sync` prunes `.git` via `SKIP_DIRS`, but leaving it in the syncable set would state the opposite of what's true.

## Verification

- `pytest tests/ai tests/sandbox` → 235 passed, 8 skipped
- `uv run task ruff-dry-all` → clean
- Simulated a scaffolded workspace (copied the template, wrote the five runtime artifacts, `git init && git add -A`). Ignored: `.bashrc`, `.dev-server.log`, `.nsjail.log`, `.npmrc`, `.env.production.local`, `dist/`, `node_modules/`. Tracked: the 26 real source files.

Not exercised end-to-end: the `sync-protected-files` round-trip against a pre-existing project (needs a live app + admin auth). It's covered indirectly by `test_gitignore_syncs_from_the_template`.

## Note

`backend/pnpm-project-template/.npmrc` is already tracked in this repo, so the new rule doesn't untrack it. It's a committed placeholder whose contents `configure_npmrc()` overwrites at scaffold time — leaving it tracked is intentional.