### PR TITLE
Stamp AgentEvent.created_at from the app clock

### DIFF
--- a/backend/src/flow44/db/events.py
+++ b/backend/src/flow44/db/events.py
@@ -3,8 +3,8 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy import JSON, Column, DateTime, ForeignKey, String, func
-from sqlmodel import Field, SQLModel, select
+from sqlalchemy import JSON, Column, DateTime, ForeignKey, String, delete, func
+from sqlmodel import Field, SQLModel, col, select
 
 from flow44.db import database
 
@@ -66,11 +66,15 @@ class AgentEvent(SQLModel, table=True):
 
 
 async def emit_event(project_id: str, event: dict[str, Any], *, notify: bool = True) -> None:
-    event_type = event.get("type", "unknown")
     event.setdefault("_ts", datetime.now(UTC).isoformat())
 
     async with database.async_session() as session:
-        row = AgentEvent(project_id=project_id, event_type=event_type, payload=event)
+        row = AgentEvent(
+            project_id=project_id,
+            event_type=event.get("type", "unknown"),
+            payload=event,
+            created_at=datetime.now(UTC),
+        )
         session.add(row)
         await session.commit()
 
@@ -90,7 +94,5 @@ async def get_events(project_id: str, after_id: int = 0) -> list[AgentEvent]:
 
 async def clear_events(project_id: str) -> None:
     async with database.async_session() as session:
-        result = await session.execute(select(AgentEvent).where(AgentEvent.project_id == project_id))
-        for row in result.scalars().all():
-            await session.delete(row)
+        await session.execute(delete(AgentEvent).where(col(AgentEvent.project_id) == project_id))
         await session.commit()

--- a/backend/tests/db/test_db.py
+++ b/backend/tests/db/test_db.py
@@ -247,6 +247,24 @@ class TestAgentEventCRUD:
         events = await get_events(project.id)
         assert events == []
 
+    async def test_emit_event_created_at_comes_from_the_app_clock(self, test_db, monkeypatch):
+        # A db server_default would stamp ~now instead of the frozen value, and would disagree
+        # with payload._ts — which the history endpoint replays in place of created_at.
+        frozen = datetime(2020, 1, 1, 12, 0, tzinfo=UTC)
+
+        class FrozenDatetime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return frozen
+
+        monkeypatch.setattr("flow44.db.events.datetime", FrozenDatetime)
+        project = await create_project("App", user_id="test-user")
+        await emit_event(project.id, {"type": "phase", "phase": "designing"}, notify=False)
+
+        events = await get_events(project.id)
+        assert events[0].created_at == frozen
+        assert events[0].payload["_ts"] == frozen.isoformat()
+
     async def test_events_isolated_by_project(self, test_db):
         p1 = await create_project("App 1", user_id="test-user")
         p2 = await create_project("App 2", user_id="test-user")


### PR DESCRIPTION
`created_at` fell back to the column's `server_default`, so it came from the db clock while `payload._ts` came from the app clock. `chat_events` replays history as `{**payload, "_ts": created_at}`, so the same event showed a different timestamp live vs after a reload.

Dropping the new line and running the test shows it directly — one event, two clocks:

```
created_at = 2026-08-31 13:36:15 UTC       <- postgres now()
_ts        = '2020-01-01T12:00:00+00:00'   <- app clock (frozen in the test)
```

Also makes `clear_events` a single bulk delete instead of a SELECT plus per-row delete.

Split out of `shalom/versioning`, where `restore_version` trims chat history by comparing `AgentEvent.created_at` against `ChatMessage.created_at` — only sound if both come from the same clock. Hunks are byte-identical to that branch so they rebase away cleanly.

No schema change, no migration. `tests/db` 42 passed, `tests/api` 66 passed, `ruff-dry-all` clean.