### PR TITLE
Extract workspace_path() helper

### DIFF
--- a/backend/src/flow44/api/admin.py
+++ b/backend/src/flow44/api/admin.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -14,6 +13,7 @@ from flow44.db.platform_user import (
     remove_platform_user,
 )
 from flow44.db.project import Project, list_published_projects
+from flow44.sandbox.base import workspace_path
 from flow44.services.maintenance.runner import ProjectMaintenanceResult, run_over_projects
 from flow44.services.maintenance.sandbox_file_permissions import fix_file_permissions
 from flow44.services.maintenance.template_sync import sync_protected_template_files
@@ -96,7 +96,7 @@ async def fix_workspace_file_permissions(user_id: AdminDep) -> list[ProjectMaint
     """Make all workspace files world-writable. (new files will be world-writable already after os.umask(0))"""
 
     async def fix_permissions(project: Project) -> str:
-        workspace_dir = os.path.join(settings.WORKSPACE_BASE_DIR, project.id)
+        workspace_dir = workspace_path(project.id)
         return await asyncio.to_thread(fix_file_permissions, workspace_dir)
 
     return await run_over_projects(fix_permissions)
@@ -107,7 +107,7 @@ async def sync_protected_files(user_id: AdminDep) -> list[ProjectMaintenanceResu
     """Overwrite each project's template files with the up-to-date template if they differ."""
 
     async def sync_files(project: Project) -> str:
-        workspace_dir = os.path.join(settings.WORKSPACE_BASE_DIR, project.id)
+        workspace_dir = workspace_path(project.id)
         return await asyncio.to_thread(sync_protected_template_files, workspace_dir, settings.TEMPLATE_DIR)
 
     return await run_over_projects(sync_files)

--- a/backend/src/flow44/sandbox/base.py
+++ b/backend/src/flow44/sandbox/base.py
@@ -9,9 +9,14 @@ from typing import IO
 
 from pydantic import BaseModel
 
+from flow44.config import settings
 from flow44.sandbox.pty import BasePTY
 
 logger = logging.getLogger(__name__)
+
+
+def workspace_path(project_id: str) -> str:
+    return os.path.join(settings.WORKSPACE_BASE_DIR, project_id)
 
 
 class SandboxInfo(BaseModel, frozen=True):

--- a/backend/src/flow44/sandbox/manager.py
+++ b/backend/src/flow44/sandbox/manager.py
@@ -5,7 +5,7 @@ import shutil
 import socket
 
 from flow44.config import settings
-from flow44.sandbox.base import SandboxInfo
+from flow44.sandbox.base import SandboxInfo, workspace_path
 from flow44.sandbox.idle_reaper import idle_reaper
 from flow44.sandbox.main import PnpmSandbox, PnpmSandboxNamespace, PnpmSandboxUnix, PnpmSandboxWindows
 
@@ -61,7 +61,7 @@ class SandboxManager:
             async with self._lock:
                 port = self._take_available_port()
 
-            workspace_dir = os.path.join(settings.WORKSPACE_BASE_DIR, project_id)
+            workspace_dir = workspace_path(project_id)
             info = SandboxInfo(project_id=project_id, workspace_dir=workspace_dir, port=port)
 
             sandbox = self._create_sandbox_instance(info)
@@ -106,7 +106,7 @@ class SandboxManager:
         """
         try:
             await self.suspend_sandbox(project_id)
-            workspace_dir = os.path.join(settings.WORKSPACE_BASE_DIR, project_id)
+            workspace_dir = workspace_path(project_id)
             await asyncio.to_thread(shutil.rmtree, workspace_dir, ignore_errors=True)
         except Exception:
             logger.exception("Failed to destroy sandbox %s", project_id)

--- a/backend/tests/sandbox/test_filesystem_mixin.py
+++ b/backend/tests/sandbox/test_filesystem_mixin.py
@@ -164,11 +164,13 @@ class TestListFiles:
     async def test_skips_skip_dirs(self, sandbox: DummySandbox, tmp_path) -> None:  # type: ignore[type-arg]
         (tmp_path / "node_modules").mkdir()
         (tmp_path / "node_modules" / "pkg.js").write_text("")
+        (tmp_path / ".git").mkdir()
         (tmp_path / "src").mkdir()
         (tmp_path / "src" / "App.tsx").write_text("")
         entries = await sandbox.list_files("/")
         names = [e.name for e in entries]
         assert "node_modules" not in names
+        assert ".git" not in names
         assert "src" in names
 
     async def test_not_a_directory_raises(self, sandbox: DummySandbox) -> None:

--- a/backend/tests/sandbox/test_sandbox_manager.py
+++ b/backend/tests/sandbox/test_sandbox_manager.py
@@ -21,7 +21,8 @@ def manager(tmp_path):  # type: ignore[type-arg]
         mock_s.PNPM_STORE_DIR = str(tmp_path / ".pnpm-store")
         mock_s.WORKSPACE_BASE_DIR = workspace_base
         mgr = SandboxManager()
-        yield mgr, workspace_base, mock_s
+        with patch("flow44.sandbox.base.settings", mock_s):
+            yield mgr, workspace_base, mock_s
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`os.path.join(settings.WORKSPACE_BASE_DIR, project_id)` was duplicated at four call sites — `manager.py` (create/destroy sandbox) and `admin.py` (both maintenance endpoints). Extracted into `workspace_path()` in `sandbox/base.py`.

The other two `WORKSPACE_BASE_DIR` uses in `manager.py` act on the base dir rather than a project path and are left alone.

The manager test fixture now also patches `flow44.sandbox.base.settings`. That part is load-bearing, not cosmetic: the join resolves `settings` in `base`'s namespace, so without it the tests build paths from the real `WORKSPACE_BASE_DIR`. Dropping the patch fails `test_workspace_dir_is_under_base` with the sandbox created at `backend/data/workspaces/myproject` instead of `tmp_path`.

Rider, unrelated: 2 lines in `test_filesystem_mixin.py` asserting `.git` is filtered from `list_files`. `SKIP_DIRS` already contains it, so this pins existing behaviour. Bundled only to shrink the versioning diff — happy to drop it.

Split out of `shalom/versioning`. All five files are byte-identical to that branch, so they rebase away completely.

Note: the admin maintenance endpoints have no tests, so those two call sites are covered only by ruff and typing.

`tests/sandbox` + `tests/api` 146 passed, `ruff-dry-all` clean.